### PR TITLE
Update env-vars.md with new variables for local hosted models

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -18,8 +18,8 @@ The (public) OpenAI environment variables include:
 - `OPENAI_MODEL`: An environment variable introduced by
   [TypeChat](https://microsoft.github.io/TypeChat/docs/examples/)
   indicating the model to use (e.g.`gpt-4o`).
-- `OPENAI_BASE_URL`: The URL for an openai compatible embedding server, e.g. [Infinity](https://github.com/michaelfeil/infinity). With this option `OPENAI_API_KEY` also needs to be set, but can be any value.
-- `OPENAI_ENDPOINT`: The URL for an server compatible with the OpenAI Chat Completions API. Make sure the `OPENAI_MODEL` variable matches with the deployed model name. E.g. 'llama:3.2:1b'
+- `OPENAI_BASE_URL`: **Optional:** The URL for an OpenAI-compatible embedding server, e.g. [Infinity](https://github.com/michaelfeil/infinity). With this option `OPENAI_API_KEY` also needs to be set, but can be any value.
+- `OPENAI_ENDPOINT`: **Optional:** The URL for an server compatible with the OpenAI Chat Completions API. Make sure the `OPENAI_MODEL` variable matches with the deployed model name, e.g. 'llama:3.2:1b'
 
 ## Azure OpenAI environment variables
 


### PR DESCRIPTION
Added OpenAI variables which are required to run the example with locally hosted models.

Example got tested with locally hosted embedding model:
```bash
docker run -it -p 7997:7997  michaelf34/infinity:latest  v2  --model-id mixedbread-ai/mxbai-embed-large-v1 --device cpu --engine optimum
```

Together with a chat completion model:
```bash
ollama run llama3.2:1b
```

I was able to execute the `Getting Started` guide with the following command:
```bash
OPENAI_BASE_URL='http://localhost:7997' OPENAI_ENDPOINT='http://localhost:11434/v1/chat/completions' OPENAI_API_KEY='does-not-matter' OPENAI_MODEL="llama3.2:1b" uv run python code.py
```

Which resulted in the following output:
```bash
0.044s -- Using OpenAI
Indexing 3 messages...
Indexed 3 messages.
Got 15 semantic refs.
```

The used model uses embedding dimensions of 1024, which I adapted by changing `DEFAULT_EMBEDDING_SIZE`