### PR TITLE
Add -d/--database arg to mcp server

### DIFF
--- a/typeagent/mcp/server.py
+++ b/typeagent/mcp/server.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""Fledgling MCP server on top of knowpro."""
+"""Fledgling MCP server on top of typeagent."""
 
 import argparse
 from dataclasses import dataclass


### PR DESCRIPTION
When given, the database is assumed to be already loaded (if it isn't, it will appear empty).
When not given, an in-memory storage provider is used and loaded with the standard podcast data.

Some other cleanups.

Fixes #55.