### PR TITLE
Add coverage support for subprocesses (mcp server)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+# Used by 'make coverage'
+
+[run]
+branch = true
+parallel = true
+source = test
+
+[report]
+sort = cover

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@ __pycache__
 *_dump/
 /testdata/Episode_53_Answer_results.json
 /testdata/Episode_53_Search_results.json
-/testdata/MP/
+/testdata/MP
 /demo/env
+.coverage
 
 # VSCode
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,10 @@ test: venv
 
 .PHONY: coverage
 coverage: venv
-	.venv/bin/python -m coverage run --source=typeagent -m pytest test $(FLAGS)
-	coverage report --sort=cover
+	coverage erase
+	COVERAGE_PROCESS_START=.coveragerc .venv/bin/coverage run -m pytest test $(FLAGS)
+	coverage combine
+	coverage report
 
 .PHONY: demo
 demo: venv

--- a/typeagent/mcp/server.py
+++ b/typeagent/mcp/server.py
@@ -3,15 +3,20 @@
 
 """Fledgling MCP server on top of typeagent."""
 
+
 import argparse
 from dataclasses import dataclass
 import time
 from typing import Any
 
+import coverage
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.session import ServerSession
 from mcp.types import SamplingMessage, TextContent
 import typechat
+
+# Enable coverage.py before local imports (a no-op unless COVERAGE_PROCESS_START is set).
+coverage.process_startup()
 
 from typeagent.aitools import embeddings, utils
 from typeagent.knowpro import answers, query, searchlang
@@ -20,7 +25,6 @@ from typeagent.knowpro.answer_response_schema import AnswerResponse
 from typeagent.knowpro.search_query_schema import SearchQuery
 from typeagent.podcasts import podcast
 from typeagent.storage.memory.semrefindex import TermToSemanticRefIndex
-from typeagent.storage.sqlite import SqliteStorageProvider
 from typeagent.storage.utils import create_storage_provider
 
 


### PR DESCRIPTION
I was helped by ChatGPT 5 and Copilot (Claude Sonnet 4.5).

- Add .coveragerc with settings for [run] and [report]
- Add code to mcp/server.py to initialize coverage (effective only when COVERAGE_PROCESS_START is set)
- Add code to test_mcp_server.py to pass that env var into the subprocess (and slight refactor)
- Update Makefile so `make coverage` does the right thing now
- Fix .gitignore