### PR TITLE
Organize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,6 @@
 # Python
 __pycache__
 
-# Virtual environment
-.venv
-
 # Build
 /typeagent.egg-info
 
@@ -24,7 +21,6 @@ __pycache__
 # Coverage
 .coverage
 .coverage.*
-htmlcov
 
 # Evaluations
 /evals


### PR DESCRIPTION
Also remove `htmlcov` and `.venv` from` .gitignore` since they have their own `.gitignore` containing the single pattern `*`.