### PR TITLE
Fix cleanup in temp_db_path fixture on Windows

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -75,9 +75,14 @@ def temp_db_path() -> Iterator[str]:
     temp_file = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
     path = temp_file.name
     temp_file.close()
+
     yield path
+
     if os.path.exists(path):
-        os.remove(path)
+        try:
+            os.remove(path)
+        except PermissionError:
+            pass  # On Windows, the file might still be in use
 
 
 @pytest.fixture


### PR DESCRIPTION
The failure is one of those annoying Windows things where the virus scanner isn't done scanning a file you just wrote when you're trying to delete it. Since it's a temp file, I think leaking the file is acceptable.

See #91.