### PR TITLE
Run CI pipeline on windows too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Install Dependencies
+        shell: bash
+        run: |
+            uv sync --extra dev
+
       - name: Run Check
         shell: bash
         if: matrix.task == 'check'


### PR DESCRIPTION
#93 

Add CI execution on windows for python3.12

Example run: https://github.com/wirthual/typeagent-py/actions/runs/19415995025/job/55544389939

Check on windows currently fails with:
```bash
d:\a\typeagent-py\typeagent-py\tools\query.py
  d:\a\typeagent-py\typeagent-py\tools\query.py:606:22 - error: "read_history_file" is not a known attribute of module "readline" (reportAttributeAccessIssue)
  d:\a\typeagent-py\typeagent-py\tools\query.py:621:30 - error: "remove_history_item" is not a known attribute of module "readline" (reportAttributeAccessIssue)
  d:\a\typeagent-py\typeagent-py\tools\query.py:622:34 - error: "get_current_history_length" is not a known attribute of module "readline" (reportAttributeAccessIssue)
  d:\a\typeagent-py\typeagent-py\tools\query.py:633:22 - error: "write_history_file" is not a known attribute of module "readline" (reportAttributeAccessIssue)
4 errors, 0 warnings, 0 informations
WARNING: there is a new pyright version available (v1.1.406 -> v1.1.407).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`
```