### PR TITLE
Fix Windows-only type check errors; improve make.bat

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -31,19 +31,19 @@ goto end
 
 :check
 if not exist ".venv\" call make.bat venv
-echo Running checks...
-.venv\Scripts\pyright --pythonpath .venv\Scripts\python typeagent test
+echo Running type checks...
+.venv\Scripts\pyright --pythonpath .venv\Scripts\python typeagent test tools gmail demo
 goto end
 
 :test
 if not exist ".venv\" call make.bat venv
-echo Running tests...
+echo Running unit tests...
 .venv\Scripts\python -m pytest
 goto end
 
 :demo
 if not exist ".venv\" call make.bat venv
-echo Running demo...
+echo Running query tool...
 .venv\Scripts\python -m tools.query
 goto end
 
@@ -73,6 +73,7 @@ echo    (Sorry, I have no idea how to do that in cmd.exe.)
 goto end
 
 :clean
+echo Cleaning out build and dev artifacts...
 if exist build rmdir /s /q build
 if exist dist rmdir /s /q dist
 if exist typeagent.egg-info rmdir /s /q typeagent.egg-info

--- a/tools/query.py
+++ b/tools/query.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 import difflib
 import json
+import os
 import re
 import shlex
 import shutil
@@ -20,10 +21,13 @@ import typing
 from colorama import init as colorama_init, Fore
 import numpy as np
 
+readline = None
 try:
-    import readline
+    if os.name != "nt":
+        import readline
 except ImportError:
-    readline = None
+    pass
+
 import typechat
 
 from typeagent.aitools import embeddings


### PR DESCRIPTION
Pyright doesn't know that `readline` always fails to import on Windows and hence complained about calls of its functions.
Fixed by checking `os.name`.