### PR TITLE
More fixes related to get_multiple

### DIFF
--- a/typeagent/storage/memory/collections.py
+++ b/typeagent/storage/memory/collections.py
@@ -43,6 +43,9 @@ class MemoryCollection[T, TOrdinal: int](ICollection[T, TOrdinal]):
 
     async def get_multiple(self, arg: list[TOrdinal]) -> list[T]:
         """Retrieve multiple items by their ordinals."""
+        size = len(self.items)
+        if not all((0 <= i < size) for i in arg):
+            raise IndexError("One or more indices are out of bounds")
         return [self.items[ordinal] for ordinal in arg]
 
     @property


### PR DESCRIPTION
The "fix" for `get_multiple()` in #102 was incorrect (it returned items sorted by `semref_id` instead of corresponding to `arg`). Moreover, the tests I added were testing the messages collection, not the `semrefs` collection.

This PR fixes semref `get_multiple()` to return items in the right order (@robgruen: same solution as the .NET version!). It also optimizes messages `get_multiple()` to use the same approach. It also adds more comprehensive tests for `get_multiple()` and some other `get_` methods and `__aiter__`, *and* comprehensive tests for semref methods. The new tests also require `get_multiple()` to raise `IndexError` when any ordinal in `arg` is out of range -- this required adding code to enforce that in the memory collection code.