### PR TITLE
Update uv.lock with new typeagent version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1778,7 +1778,7 @@ wheels = [
 
 [[package]]
 name = "typeagent"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
We should really do this in tools/release.py, but we didn't last time, so here goes. This finishes the release of 0.3.3. :-)