### PR TITLE
Fix Connection Errors caused by subtle change to test_embeddings.py

### DIFF
--- a/test/test_embeddings.py
+++ b/test/test_embeddings.py
@@ -9,7 +9,8 @@ from pytest import MonkeyPatch
 import numpy as np
 
 from typeagent.aitools.embeddings import AsyncEmbeddingModel
-from conftest import embedding_model, fake_embeddings, fake_embeddings_tiktoken, FakeEmbeddings  # type: ignore
+from conftest import embedding_model  # type: ignore  # Magic, prevents side effects of mocking
+from conftest import FakeEmbeddings
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
In test_embeddings.py, test_refresh_auth() does something to its embedding_model fixture that somehow hangs around past the end of the test, causing Connection Errors in later test files (not in its own file).

I've tried various ways to fix this; the cleanest way appears to be to put back the explicit import of the embedding_model fixture.

This fixes the problem when running tests locally, but in CI it still fails. I'm at my wits' end and plan to merge this despite the CI failures -- it's possible that the CI failures disappear once it's in main, and even if not, at least this fixes local test runs.

Tries to deal with #133.