### PR TITLE
add ref when checking out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           exit 1  
 
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
for pull_request_target, we must explicitly checkout the PR's code without this, checkout defaults to the base branch (main), not the PR.
