### PR TITLE
Update ci.yml to depend more on Makefile or make.bat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true  
+  cancel-in-progress: true
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
Basically I removed the "Install dependencies" step from the Check, Format and Test jobs, in favor of the auto-create-venv behavior built into the Makefile / make.bat. Except for the Get Keys job where I had to create two Install dependencies steps, one for each platform (using `make sync` / `./make.bat sync`).

This hopefully reduces the number of times we have to change ci.yml due to some workflow change. But now we have to test this. How?