### PR TITLE
Fix ci.yml -- use ./make.bat for Windows test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Run Test (Windows)
         if: runner.os == 'Windows'
         run: |
-            make test
+            ./make.bat test
 
   online-test:
     needs: permissions-check


### PR DESCRIPTION
This was a typo in #158.