### PR TITLE
perf: Vectorize fuzzy_lookup_embedding with numpy ops

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,5 +92,6 @@ dev = [
   "pyright>=1.1.408",  # 407 has a regression
   "pytest>=8.3.5",
   "pytest-asyncio>=0.26.0",
+  "pytest-benchmark>=5.1.0",
   "pytest-mock>=3.14.0",
 ]

--- a/src/typeagent/aitools/vectorbase.py
+++ b/src/typeagent/aitools/vectorbase.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
@@ -132,17 +132,33 @@ class VectorBase:
             min_score = 0.0
         if len(self._vectors) == 0:
             return []
-        # This line does most of the work:
-        scores: Iterable[float] = np.dot(self._vectors, embedding)
-        scored_ordinals = [
-            ScoredInt(i, score)
-            for i, score in enumerate(scores)
-            if score >= min_score and (predicate is None or predicate(i))
-        ]
-        scored_ordinals.sort(key=lambda x: x.score, reverse=True)
-        return scored_ordinals[:max_hits]
+        scores = np.dot(self._vectors, embedding)
+        if predicate is None:
+            # Stay in numpy: filter by score, then top-k via argpartition.
+            indices = np.flatnonzero(scores >= min_score)
+            if len(indices) == 0:
+                return []
+            filtered_scores = scores[indices]
+            if len(indices) <= max_hits:
+                order = np.argsort(filtered_scores)[::-1]
+            else:
+                top_k = np.argpartition(filtered_scores, -max_hits)[-max_hits:]
+                order = top_k[np.argsort(filtered_scores[top_k])[::-1]]
+            return [
+                ScoredInt(int(indices[i]), float(filtered_scores[i])) for i in order
+            ]
+        else:
+            # Predicate path: pre-filter by score in numpy, apply predicate
+            # only to candidates above the threshold.
+            candidates = np.flatnonzero(scores >= min_score)
+            scored_ordinals = [
+                ScoredInt(int(i), float(scores[i]))
+                for i in candidates
+                if predicate(int(i))
+            ]
+            scored_ordinals.sort(key=lambda x: x.score, reverse=True)
+            return scored_ordinals[:max_hits]
 
-    # TODO: Make this and fuzzy_lookup_embedding() more similar.
     def fuzzy_lookup_embedding_in_subset(
         self,
         embedding: NormalizedEmbedding,
@@ -150,10 +166,27 @@ class VectorBase:
         max_hits: int | None = None,
         min_score: float | None = None,
     ) -> list[ScoredInt]:
-        ordinals_set = set(ordinals_of_subset)
-        return self.fuzzy_lookup_embedding(
-            embedding, max_hits, min_score, lambda i: i in ordinals_set
-        )
+        if max_hits is None:
+            max_hits = 10
+        if min_score is None:
+            min_score = 0.0
+        if not ordinals_of_subset or len(self._vectors) == 0:
+            return []
+        # Compute dot products only for the subset instead of all vectors.
+        subset = np.asarray(ordinals_of_subset)
+        scores = np.dot(self._vectors[subset], embedding)
+        indices = np.flatnonzero(scores >= min_score)
+        if len(indices) == 0:
+            return []
+        filtered_scores = scores[indices]
+        if len(indices) <= max_hits:
+            order = np.argsort(filtered_scores)[::-1]
+        else:
+            top_k = np.argpartition(filtered_scores, -max_hits)[-max_hits:]
+            order = top_k[np.argsort(filtered_scores[top_k])[::-1]]
+        return [
+            ScoredInt(int(subset[indices[i]]), float(filtered_scores[i])) for i in order
+        ]
 
     async def fuzzy_lookup(
         self,

--- a/tests/benchmarks/test_benchmark_vectorbase.py
+++ b/tests/benchmarks/test_benchmark_vectorbase.py
@@ -1,0 +1,103 @@
+"""Benchmarks for VectorBase.fuzzy_lookup_embedding.
+
+Measures whether the numpy-vectorized path is meaningfully faster than
+Python-level iteration at realistic conversation sizes (1K–10K vectors).
+
+Usage:
+    uv run python -m pytest tests/benchmarks/test_benchmark_vectorbase.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from typeagent.aitools.vectorbase import ScoredInt, TextEmbeddingIndexSettings, VectorBase
+
+
+# -- Helpers ------------------------------------------------------------------
+
+
+class StubEmbeddingModel:
+    """Minimal stub that satisfies TextEmbeddingIndexSettings without network."""
+
+    async def get_embedding(self, key: str) -> np.ndarray:
+        raise NotImplementedError
+
+    async def get_embedding_nocache(self, key: str) -> np.ndarray:
+        raise NotImplementedError
+
+    async def get_embeddings(self, keys: list[str]) -> np.ndarray:
+        raise NotImplementedError
+
+    async def get_embeddings_nocache(self, keys: list[str]) -> np.ndarray:
+        raise NotImplementedError
+
+    def add_embedding(self, key: str, embedding: np.ndarray) -> None:
+        pass
+
+
+def make_vectorbase(n: int, dim: int = 384) -> tuple[VectorBase, np.ndarray]:
+    """Create a VectorBase with *n* random normalized embeddings."""
+    rng = np.random.default_rng(42)
+    vecs = rng.standard_normal((n, dim)).astype(np.float32)
+    norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+    vecs /= norms
+
+    settings = TextEmbeddingIndexSettings(embedding_model=StubEmbeddingModel())
+    vb = VectorBase(settings)
+    vb.add_embeddings(None, vecs)
+
+    query = rng.standard_normal(dim).astype(np.float32)
+    query /= np.linalg.norm(query)
+    return vb, query
+
+
+# -- Fixtures -----------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def vb_1k() -> tuple[VectorBase, np.ndarray]:
+    return make_vectorbase(1_000)
+
+
+@pytest.fixture(scope="module")
+def vb_10k() -> tuple[VectorBase, np.ndarray]:
+    return make_vectorbase(10_000)
+
+
+# -- Benchmarks ---------------------------------------------------------------
+
+
+class TestFuzzyLookupEmbedding:
+    """fuzzy_lookup_embedding at realistic conversation sizes."""
+
+    def test_1k_vectors(self, benchmark, vb_1k: tuple[VectorBase, np.ndarray]) -> None:
+        vb, query = vb_1k
+        result = benchmark(vb.fuzzy_lookup_embedding, query, max_hits=10, min_score=0.0)
+        assert len(result) == 10
+        assert all(isinstance(r, ScoredInt) for r in result)
+
+    def test_10k_vectors(self, benchmark, vb_10k: tuple[VectorBase, np.ndarray]) -> None:
+        vb, query = vb_10k
+        result = benchmark(vb.fuzzy_lookup_embedding, query, max_hits=10, min_score=0.0)
+        assert len(result) == 10
+
+
+class TestFuzzyLookupEmbeddingInSubset:
+    """fuzzy_lookup_embedding_in_subset — subset of 1K from 10K vectors."""
+
+    def test_subset_1k_of_10k(
+        self, benchmark, vb_10k: tuple[VectorBase, np.ndarray]
+    ) -> None:
+        vb, query = vb_10k
+        rng = np.random.default_rng(99)
+        subset = rng.choice(10_000, size=1_000, replace=False).tolist()
+        result = benchmark(
+            vb.fuzzy_lookup_embedding_in_subset,
+            query,
+            subset,
+            max_hits=10,
+            min_score=0.0,
+        )
+        assert len(result) == 10

--- a/tests/benchmarks/test_benchmark_vectorbase.py
+++ b/tests/benchmarks/test_benchmark_vectorbase.py
@@ -3,7 +3,8 @@
 Measures whether the numpy-vectorized path is meaningfully faster than
 Python-level iteration at realistic conversation sizes (1K–10K vectors).
 
-Usage:
+Requires ``pytest-benchmark`` (``uv pip install pytest-benchmark``)::
+
     uv run python -m pytest tests/benchmarks/test_benchmark_vectorbase.py -v
 """
 
@@ -12,29 +13,11 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from typeagent.aitools.model_adapters import create_test_embedding_model
 from typeagent.aitools.vectorbase import ScoredInt, TextEmbeddingIndexSettings, VectorBase
 
 
 # -- Helpers ------------------------------------------------------------------
-
-
-class StubEmbeddingModel:
-    """Minimal stub that satisfies TextEmbeddingIndexSettings without network."""
-
-    async def get_embedding(self, key: str) -> np.ndarray:
-        raise NotImplementedError
-
-    async def get_embedding_nocache(self, key: str) -> np.ndarray:
-        raise NotImplementedError
-
-    async def get_embeddings(self, keys: list[str]) -> np.ndarray:
-        raise NotImplementedError
-
-    async def get_embeddings_nocache(self, keys: list[str]) -> np.ndarray:
-        raise NotImplementedError
-
-    def add_embedding(self, key: str, embedding: np.ndarray) -> None:
-        pass
 
 
 def make_vectorbase(n: int, dim: int = 384) -> tuple[VectorBase, np.ndarray]:
@@ -44,7 +27,7 @@ def make_vectorbase(n: int, dim: int = 384) -> tuple[VectorBase, np.ndarray]:
     norms = np.linalg.norm(vecs, axis=1, keepdims=True)
     vecs /= norms
 
-    settings = TextEmbeddingIndexSettings(embedding_model=StubEmbeddingModel())
+    settings = TextEmbeddingIndexSettings(embedding_model=create_test_embedding_model())
     vb = VectorBase(settings)
     vb.add_embeddings(None, vecs)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1684,6 +1684,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1933,6 +1942,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]
@@ -2399,6 +2421,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
     { name = "pytest-mock" },
 ]
 
@@ -2437,6 +2460,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Replace Python-level list comprehension + sort in `fuzzy_lookup_embedding` with numpy vectorized operations (`np.flatnonzero`, `np.argpartition`)
- Rewrite `fuzzy_lookup_embedding_in_subset` to compute dot products only for subset indices instead of scanning all vectors + predicate filter

## Benchmark (Azure Standard_D2s_v5, 384-dim embeddings)

| Benchmark | Before | After | Speedup |
|---|---:|---:|---:|
| `fuzzy_lookup_embedding` (1K vecs) | 259μs | 64μs | **4.1x** |
| `fuzzy_lookup_embedding` (10K vecs) | 6.1ms | 531μs | **11.5x** |
| `fuzzy_lookup_embedding_in_subset` (1K of 10K) | 3.2ms | 244μs | **13.0x** |

## Why this matters

These functions are called on every `fuzzy_lookup` — the core search path for conversation queries. At 10K vectors (a long conversation), the Python iteration path takes 6ms per query. With multiple queries per request (e.g., searching across properties + timestamps + topics), this adds up.

The numpy path stays in C for the heavy lifting: score filtering via `np.flatnonzero`, O(n) top-k via `np.argpartition`, and subset dot products via fancy indexing. `ScoredInt` objects are only created for the final top-k results.

## Test plan

- [x] `make format check test` passes (470 passed, 12 pre-existing online test failures)
- [x] Benchmark included: `tests/benchmarks/test_benchmark_vectorbase.py`