### PR TITLE
Add 'make eval'. Fix crash in pprint(). Reformat some files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format: venv
 
 .PHONY: check
 check: venv
-	uv run pyright --pythonpath python src tests tools examples
+	uv run pyright src tests tools examples
 
 .PHONY: test
 test: venv

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ demo: venv
 compare: venv
 	.venv/bin/python -m tools.query --batch $(FLAGS)
 
+.PHONY: eval
+eval: venv
+	rm -f eval.db
+	.venv/bin/python tools/load_json.py --database eval.db tests/testdata/Episode_53_AdrianTchaikovsky_index
+	.venv/bin/python tools/query.py --batch --database eval.db --answer-results tests/testdata/Episode_53_Answer_results.json --search-results tests/testdata/Episode_53_Search_results.json $(FLAGS)
+
 .PHONY: mcp
 mcp: venv
 	.venv/bin/mcp dev src/typeagent/mcp/server.py

--- a/Makefile
+++ b/Makefile
@@ -8,49 +8,49 @@ all: venv format check test build
 
 .PHONY: format
 format: venv
-	.venv/bin/isort src tests tools examples $(FLAGS)
-	.venv/bin/black -tpy312 src tests tools examples $(FLAGS)
+	uv run isort src tests tools examples $(FLAGS)
+	uv run black -tpy312 src tests tools examples $(FLAGS)
 
 .PHONY: check
 check: venv
-	.venv/bin/pyright --pythonpath .venv/bin/python src tests tools examples
+	uv run pyright --pythonpath python src tests tools examples
 
 .PHONY: test
 test: venv
-	.venv/bin/pytest $(FLAGS)
+	uv run pytest $(FLAGS)
 
 .PHONY: coverage
 coverage: venv
 	coverage erase
-	COVERAGE_PROCESS_START=.coveragerc .venv/bin/coverage run -m pytest $(FLAGS)
+	COVERAGE_PROCESS_START=.coveragerc uv run coverage run -m pytest $(FLAGS)
 	coverage combine
 	coverage report
 
 .PHONY: demo
 demo: venv
-	.venv/bin/python -m tools.query $(FLAGS)
+	uv run python -m tools.query $(FLAGS)
 
 .PHONY: compare
 compare: venv
-	.venv/bin/python -m tools.query --batch $(FLAGS)
+	uv run python -m tools.query --batch $(FLAGS)
 
 .PHONY: eval
 eval: venv
 	rm -f eval.db
-	.venv/bin/python tools/load_json.py --database eval.db tests/testdata/Episode_53_AdrianTchaikovsky_index
-	.venv/bin/python tools/query.py --batch --database eval.db --answer-results tests/testdata/Episode_53_Answer_results.json --search-results tests/testdata/Episode_53_Search_results.json $(FLAGS)
+	uv run python tools/load_json.py --database eval.db tests/testdata/Episode_53_AdrianTchaikovsky_index
+	uv run python tools/query.py --batch --database eval.db --answer-results tests/testdata/Episode_53_Answer_results.json --search-results tests/testdata/Episode_53_Search_results.json $(FLAGS)
 
 .PHONY: mcp
 mcp: venv
-	.venv/bin/mcp dev src/typeagent/mcp/server.py
+	uv run mcp dev src/typeagent/mcp/server.py
 
 .PHONY: profile
 profile: venv
-	</dev/null .venv/bin/python -m cProfile -s ncalls -m test.cmpsearch --interactive --podcast ~/AISystems-Archive/data/knowpro/test/indexes/All_Episodes_index | head -60
+	</dev/null uv run python -m cProfile -s ncalls -m test.cmpsearch --interactive --podcast ~/AISystems-Archive/data/knowpro/test/indexes/All_Episodes_index | head -60
 
 .PHONY: scaling
 scaling: venv
-	</dev/null .venv/bin/python -m test.cmpsearch --interactive --podcast ~/AISystems-Archive/data/knowpro/test/indexes/All_Episodes_index
+	</dev/null uv run python -m test.cmpsearch --interactive --podcast ~/AISystems-Archive/data/knowpro/test/indexes/All_Episodes_index
 
 .PHONY: build
 build: venv
@@ -58,7 +58,7 @@ build: venv
 
 .PHONY: release
 release: venv
-	.venv/bin/python tools/release.py $(VERSION)
+	uv run python tools/release.py $(VERSION)
 
 .PHONY: venv
 venv: .venv
@@ -66,10 +66,10 @@ venv: .venv
 .venv:
 	@echo "(If 'uv' fails with 'No such file or directory', try 'make install-uv')"
 	uv sync -q $(FLAGS)
-	.venv/bin/black --version
+	uv run black --version
 	@echo "(If 'pyright' fails with 'error while loading shared libraries: libatomic.so.1:', try 'make install-libatomic')"
-	.venv/bin/pyright --version
-	.venv/bin/pytest --version
+	uv run pyright --version
+	uv run pytest --version
 
 .PHONY: sync
 sync:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: venv format check test build
 .PHONY: format
 format: venv
 	.venv/bin/isort src tests tools examples $(FLAGS)
-	.venv/bin/black -tpy312 -tpy313 -tpy314 src tests tools examples $(FLAGS)
+	.venv/bin/black -tpy312 src tests tools examples $(FLAGS)
 
 .PHONY: check
 check: venv

--- a/make.bat
+++ b/make.bat
@@ -27,26 +27,26 @@ goto help
 :format
 if not exist ".venv\" call make.bat venv
 echo Formatting code...
-.venv\Scripts\isort src tests tools examples
-.venv\Scripts\black src tests tools examples
+uv run isort src tests tools examples
+uv run black -tpy312 src tests tools examples
 goto end
 
 :check
 if not exist ".venv\" call make.bat venv
 echo Running type checks...
-.venv\Scripts\pyright --pythonpath .venv\Scripts\python src tests tools examples
+uv run pyright src tests tools examples
 goto end
 
 :test
 if not exist ".venv\" call make.bat venv
 echo Running unit tests...
-.venv\Scripts\python -m pytest
+uv run pytest
 goto end
 
 :demo
 if not exist ".venv\" call make.bat venv
 echo Running query tool...
-.venv\Scripts\python -m tools.query
+uv run python -m tools.query
 goto end
 
 :build
@@ -58,10 +58,10 @@ goto end
 :venv
 echo Creating virtual environment...
 uv sync -q
-.venv\Scripts\python --version
-.venv\Scripts\black --version
-.venv\Scripts\pyright --version
-.venv\Scripts\python -m pytest --version
+uv run python --version
+uv run black --version
+uv run pyright --version
+uv run pytest --version
 goto end
 
 :sync

--- a/src/typeagent/aitools/utils.py
+++ b/src/typeagent/aitools/utils.py
@@ -55,13 +55,18 @@ def format_code(text: str, line_width=None) -> str:
     """Format a Python literal expression using pprint.
 
     NOTE: The text must be a valid Python literal expression (as produced by repr()).
+    Falls back to plain text formatting if the text is not a valid literal.
     """
     import ast
     import pprint
 
     if line_width is None:
         line_width = min(200, shutil.get_terminal_size().columns)
-    return pprint.pformat(ast.literal_eval(text), width=line_width)
+    try:
+        return pprint.pformat(ast.literal_eval(text), width=line_width)
+    except (ValueError, SyntaxError):
+        # Fall back to simple pprint of the string itself if it's not a valid literal
+        return pprint.pformat(text, width=line_width)
 
 
 def reindent(text: str) -> str:

--- a/src/typeagent/aitools/utils.py
+++ b/src/typeagent/aitools/utils.py
@@ -48,7 +48,7 @@ def pretty_print(obj: object, prefix: str = "", suffix: str = "") -> None:
     import pprint
 
     line_width = min(200, shutil.get_terminal_size().columns)
-    print(pprint.pformat(obj, width=line_width))
+    print(prefix + pprint.pformat(obj, width=line_width) + suffix)
 
 
 def format_code(text: str, line_width=None) -> str:

--- a/src/typeagent/knowpro/conversation_base.py
+++ b/src/typeagent/knowpro/conversation_base.py
@@ -13,11 +13,13 @@ from . import (
     answer_response_schema,
     answers,
     convknowledge,
-    knowledge_schema as kplib,
+)
+from . import (
     search_query_schema,
     searchlang,
     secindex,
 )
+from . import knowledge_schema as kplib
 from ..aitools import model_adapters, utils
 from ..storage.memory import semrefindex
 from .convsettings import ConversationSettings

--- a/src/typeagent/knowpro/knowledge.py
+++ b/src/typeagent/knowpro/knowledge.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 
 from typechat import Result, TypeChatLanguageModel
 
-from . import convknowledge, knowledge_schema as kplib
+from . import convknowledge
+from . import knowledge_schema as kplib
 from ..aitools import model_adapters
 from .interfaces import IKnowledgeExtractor
 

--- a/src/typeagent/storage/memory/semrefindex.py
+++ b/src/typeagent/storage/memory/semrefindex.py
@@ -7,7 +7,9 @@ from collections.abc import AsyncIterable, Callable
 
 from typechat import Failure
 
-from ...knowpro import convknowledge, knowledge_schema as kplib, secindex
+from ...knowpro import convknowledge
+from ...knowpro import knowledge_schema as kplib
+from ...knowpro import secindex
 from ...knowpro.convsettings import ConversationSettings, SemanticRefIndexSettings
 from ...knowpro.interfaces import (  # Interfaces.; Other imports.
     IConversation,

--- a/tests/benchmarks/test_benchmark_vectorbase.py
+++ b/tests/benchmarks/test_benchmark_vectorbase.py
@@ -14,8 +14,11 @@ import numpy as np
 import pytest
 
 from typeagent.aitools.model_adapters import create_test_embedding_model
-from typeagent.aitools.vectorbase import ScoredInt, TextEmbeddingIndexSettings, VectorBase
-
+from typeagent.aitools.vectorbase import (
+    ScoredInt,
+    TextEmbeddingIndexSettings,
+    VectorBase,
+)
 
 # -- Helpers ------------------------------------------------------------------
 
@@ -61,7 +64,9 @@ class TestFuzzyLookupEmbedding:
         assert len(result) == 10
         assert all(isinstance(r, ScoredInt) for r in result)
 
-    def test_10k_vectors(self, benchmark, vb_10k: tuple[VectorBase, np.ndarray]) -> None:
+    def test_10k_vectors(
+        self, benchmark, vb_10k: tuple[VectorBase, np.ndarray]
+    ) -> None:
         vb, query = vb_10k
         result = benchmark(vb.fuzzy_lookup_embedding, query, max_hits=10, min_score=0.0)
         assert len(result) == 10

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -5,7 +5,8 @@ import pytest
 
 from typechat import Failure, Result, Success
 
-from typeagent.knowpro import convknowledge, knowledge_schema as kplib
+from typeagent.knowpro import convknowledge
+from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.knowledge import (
     create_knowledge_extractor,
     extract_knowledge_from_text,

--- a/tests/test_semrefindex.py
+++ b/tests/test_semrefindex.py
@@ -20,7 +20,12 @@ from typeagent.knowpro.interfaces import (
     ITermToSemanticRefIndex,
     Topic,
 )
-from typeagent.knowpro.knowledge_schema import Action, ConcreteEntity, Facet, KnowledgeResponse
+from typeagent.knowpro.knowledge_schema import (
+    Action,
+    ConcreteEntity,
+    Facet,
+    KnowledgeResponse,
+)
 from typeagent.storage import SqliteStorageProvider
 from typeagent.storage.memory import MemoryStorageProvider
 from typeagent.storage.memory.semrefindex import (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,19 +63,22 @@ def test_format_code_non_literal():
     was called on repr() of objects containing non-literal elements (e.g., AST nodes,
     custom class instances).
     """
-    import ast
 
-    # Create an AST node (a non-literal object whose repr() can't be evaluated)
-    ast_node = ast.Call()
-    non_literal_repr = repr(ast_node)
-    # This repr looks like: <ast.Call object at 0x...>
+    # Create a custom class instance (a non-literal object whose repr() can't be
+    # evaluated with ast.literal_eval)
+    class CustomClass:
+        pass
+
+    obj = CustomClass()
+    non_literal_repr = repr(obj)
+    # This repr looks like: <__main__.CustomClass object at 0x...>
 
     # format_code() should handle this gracefully without raising ValueError
     result = utils.format_code(non_literal_repr)
     assert isinstance(result, str)
     assert len(result) > 0
     # The result should contain the non-literal repr (possibly wrapped in quotes)
-    assert "ast.Call object" in result or "ast" in result
+    assert "CustomClass object" in result or "CustomClass" in result
 
 
 def test_load_dotenv(really_needs_auth):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,6 +56,28 @@ def test_format_code_nested():
     assert parsed == obj
 
 
+def test_format_code_non_literal():
+    """Test that format_code gracefully handles non-literal expressions.
+
+    Regression test for commit 59be9a5 which broke debug output when format_code()
+    was called on repr() of objects containing non-literal elements (e.g., AST nodes,
+    custom class instances).
+    """
+    import ast
+
+    # Create an AST node (a non-literal object whose repr() can't be evaluated)
+    ast_node = ast.Call()
+    non_literal_repr = repr(ast_node)
+    # This repr looks like: <ast.Call object at 0x...>
+
+    # format_code() should handle this gracefully without raising ValueError
+    result = utils.format_code(non_literal_repr)
+    assert isinstance(result, str)
+    assert len(result) > 0
+    # The result should contain the non-literal repr (possibly wrapped in quotes)
+    assert "ast.Call object" in result or "ast" in result
+
+
 def test_load_dotenv(really_needs_auth):
     # Call load_dotenv and check for at least one expected key
     load_dotenv()

--- a/tools/query.py
+++ b/tools/query.py
@@ -36,13 +36,15 @@ from typeagent.aitools import embeddings, model_adapters, utils
 from typeagent.knowpro import (
     answer_response_schema,
     answers,
-    knowledge_schema as kplib,
+)
+from typeagent.knowpro import (
     query,
     search,
     search_query_schema,
     searchlang,
     serialization,
 )
+from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.convsettings import ConversationSettings
 from typeagent.knowpro.interfaces import (
     IConversation,

--- a/tools/release.py
+++ b/tools/release.py
@@ -450,9 +450,15 @@ Examples:
 
     if exit_code != 0:
         if args.force:
-            print("Warning: Failed to create PR -- you can create it yourself", file=sys.stderr)
+            print(
+                "Warning: Failed to create PR -- you can create it yourself",
+                file=sys.stderr,
+            )
         else:
-            print("Error: Failed to create PR -- but you can create it yourself", file=sys.stderr)
+            print(
+                "Error: Failed to create PR -- but you can create it yourself",
+                file=sys.stderr,
+            )
             return 1
 
     if args.dry_run:

--- a/uv.lock
+++ b/uv.lock
@@ -2386,7 +2386,6 @@ version = "0.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },
-    { name = "black" },
     { name = "colorama" },
     { name = "mcp", extra = ["cli"] },
     { name = "numpy" },
@@ -2410,6 +2409,7 @@ logfire = [
 dev = [
     { name = "azure-mgmt-authorization" },
     { name = "azure-mgmt-keyvault" },
+    { name = "black" },
     { name = "coverage" },
     { name = "google-api-python-client" },
     { name = "google-auth-httplib2" },
@@ -2428,7 +2428,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "azure-identity", specifier = ">=1.22.0" },
-    { name = "black", specifier = ">=25.12.0" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=4.1.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.1" },
@@ -2449,6 +2448,7 @@ provides-extras = ["logfire"]
 dev = [
     { name = "azure-mgmt-authorization", specifier = ">=4.0.0" },
     { name = "azure-mgmt-keyvault", specifier = ">=12.1.1" },
+    { name = "black", specifier = ">=25.12.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.9.1" },
     { name = "google-api-python-client", specifier = ">=2.184.0" },
     { name = "google-auth-httplib2", specifier = ">=0.2.0" },


### PR DESCRIPTION
Apparently at least one of isort and black was updated and now produces more compact code in some cases.

Also change the black call in Makefile to use only -tpy312 since black on 3.12 cannot parse back the py314 code it generated (maybe only the last -t flag was effective?).

And finally make Makefile more robust by using `uv run X` instead of `.venv/bin/X`.