### PR TITLE
fix: increase OpenAI client max_retries to handle 429 rate limits

### DIFF
--- a/src/typeagent/aitools/model_adapters.py
+++ b/src/typeagent/aitools/model_adapters.py
@@ -182,6 +182,7 @@ def _make_azure_provider(
             azure_endpoint=azure_endpoint,
             api_version=api_version,
             azure_ad_token_provider=token_provider.get_token,
+            max_retries=5,
         )
     else:
         apim_key = os.getenv("AZURE_APIM_SUBSCRIPTION_KEY")
@@ -192,6 +193,7 @@ def _make_azure_provider(
             default_headers=(
                 {"Ocp-Apim-Subscription-Key": apim_key} if apim_key else None
             ),
+            max_retries=5,
         )
     return AzureProvider(openai_client=client)
 

--- a/src/typeagent/aitools/utils.py
+++ b/src/typeagent/aitools/utils.py
@@ -274,7 +274,7 @@ def create_async_openai_client(
     from openai import AsyncAzureOpenAI, AsyncOpenAI
 
     if openai_api_key := os.getenv("OPENAI_API_KEY"):
-        return AsyncOpenAI(api_key=openai_api_key, base_url=base_url)
+        return AsyncOpenAI(api_key=openai_api_key, base_url=base_url, max_retries=5)
 
     elif azure_api_key := os.getenv("AZURE_OPENAI_API_KEY"):
         azure_api_key = get_azure_api_key(azure_api_key)
@@ -289,6 +289,7 @@ def create_async_openai_client(
             default_headers=(
                 {"Ocp-Apim-Subscription-Key": apim_key} if apim_key else None
             ),
+            max_retries=5,
         )
 
     else:


### PR DESCRIPTION
## Summary
- Bumps `max_retries` from the default (2) to 5 across all four `AsyncOpenAI`/`AsyncAzureOpenAI` construction sites (`create_async_openai_client` and `_make_azure_provider`)
- The openai SDK's built-in exponential backoff handles transient 429s automatically — this just gives it more attempts
- Three online tests (`test_ingest_podcast`, `test_query_method_basic`, `test_transcript_knowledge_extraction_slow`) were failing intermittently due to 429s

## Test plan
- [x] `make check` (pyright) — 0 errors
- [x] `pytest tests/test_model_adapters.py tests/test_utils.py` — 29/30 pass (1 pre-existing failure fixed in #244)