### PR TITLE
set COVERAGE_PROCESS_START, which the Makefile does.

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -48,9 +48,11 @@ goto end
 if not exist ".venv\" call make.bat venv
 echo Running test coverage...
 uv run coverage erase
+set COVERAGE_PROCESS_START=.coveragerc 
 uv run coverage run -m pytest
 uv run coverage combine
 uv run coverage report
+set COVERAGE_PROCESS_START=
 goto end
 
 

--- a/make.bat
+++ b/make.bat
@@ -45,14 +45,15 @@ uv run pytest
 goto end
 
 :coverage
+setlocal
 if not exist ".venv\" call make.bat venv
 echo Running test coverage...
 uv run coverage erase
-set COVERAGE_PROCESS_START=.coveragerc 
+set "COVERAGE_PROCESS_START=.coveragerc"
 uv run coverage run -m pytest
 uv run coverage combine
 uv run coverage report
-set COVERAGE_PROCESS_START=
+endlocal
 goto end
 
 


### PR DESCRIPTION
Without it, subprocess coverage (spawned by pytest) isn't collected