### PR TITLE
Dispose of create_async_openai_client

### DIFF
--- a/src/typeagent/aitools/utils.py
+++ b/src/typeagent/aitools/utils.py
@@ -252,52 +252,6 @@ def get_azure_api_key(azure_api_key: str) -> str:
     return azure_api_key
 
 
-def create_async_openai_client(
-    endpoint_envvar: str = "AZURE_OPENAI_ENDPOINT",
-    base_url: str | None = None,
-):
-    """Create AsyncOpenAI or AsyncAzureOpenAI client based on environment variables.
-
-    Returns the appropriate async OpenAI client based on what credentials are available.
-    Prefers OPENAI_API_KEY over AZURE_OPENAI_API_KEY.
-
-    Args:
-        endpoint_envvar: Environment variable name for Azure endpoint (default: AZURE_OPENAI_ENDPOINT).
-        base_url: Optional base URL override for OpenAI client.
-
-    Returns:
-        AsyncOpenAI or AsyncAzureOpenAI client instance.
-
-    Raises:
-        RuntimeError: If neither OPENAI_API_KEY nor AZURE_OPENAI_API_KEY is set.
-    """
-    from openai import AsyncAzureOpenAI, AsyncOpenAI
-
-    if openai_api_key := os.getenv("OPENAI_API_KEY"):
-        return AsyncOpenAI(api_key=openai_api_key, base_url=base_url, max_retries=5)
-
-    elif azure_api_key := os.getenv("AZURE_OPENAI_API_KEY"):
-        azure_api_key = get_azure_api_key(azure_api_key)
-        azure_endpoint, api_version = parse_azure_endpoint(endpoint_envvar)
-
-        apim_key = os.getenv("AZURE_APIM_SUBSCRIPTION_KEY")
-
-        return AsyncAzureOpenAI(
-            api_version=api_version,
-            azure_endpoint=azure_endpoint,
-            api_key=azure_api_key,
-            default_headers=(
-                {"Ocp-Apim-Subscription-Key": apim_key} if apim_key else None
-            ),
-            max_retries=5,
-        )
-
-    else:
-        raise RuntimeError(
-            "Neither OPENAI_API_KEY nor AZURE_OPENAI_API_KEY was provided."
-        )
-
-
 def resolve_azure_model_name(
     model_name: str,
     endpoint_envvar: str = "AZURE_OPENAI_ENDPOINT",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,7 +25,11 @@ from mcp.types import (
 from openai.types.chat import ChatCompletionMessageParam
 import typechat
 
-from typeagent.aitools.utils import create_async_openai_client, resolve_azure_model_name
+from typeagent.aitools.utils import (
+    get_azure_api_key,
+    parse_azure_endpoint,
+    resolve_azure_model_name,
+)
 from typeagent.knowpro import answers, searchlang
 from typeagent.knowpro.answer_response_schema import AnswerResponse
 from typeagent.knowpro.convsettings import ConversationSettings
@@ -38,6 +42,38 @@ from typeagent.mcp.server import (
 )
 
 from conftest import EPISODE_53_INDEX
+
+
+def create_async_openai_client(
+    endpoint_envvar: str = "AZURE_OPENAI_ENDPOINT",
+    base_url: str | None = None,
+):
+    """Create AsyncOpenAI or AsyncAzureOpenAI client based on environment variables."""
+    from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+    if openai_api_key := os.getenv("OPENAI_API_KEY"):
+        return AsyncOpenAI(api_key=openai_api_key, base_url=base_url, max_retries=5)
+
+    elif azure_api_key := os.getenv("AZURE_OPENAI_API_KEY"):
+        azure_api_key = get_azure_api_key(azure_api_key)
+        azure_endpoint, api_version = parse_azure_endpoint(endpoint_envvar)
+
+        apim_key = os.getenv("AZURE_APIM_SUBSCRIPTION_KEY")
+
+        return AsyncAzureOpenAI(
+            api_version=api_version,
+            azure_endpoint=azure_endpoint,
+            api_key=azure_api_key,
+            default_headers=(
+                {"Ocp-Apim-Subscription-Key": apim_key} if apim_key else None
+            ),
+            max_retries=5,
+        )
+
+    else:
+        raise RuntimeError(
+            "Neither OPENAI_API_KEY nor AZURE_OPENAI_API_KEY was provided."
+        )
 
 
 @pytest.fixture

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,7 +6,6 @@
 import json
 import os
 import sys
-from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -22,14 +21,9 @@ from mcp.types import (
     SamplingMessage,
     TextContent,
 )
-from openai.types.chat import ChatCompletionMessageParam
 import typechat
 
-from typeagent.aitools.utils import (
-    get_azure_api_key,
-    parse_azure_endpoint,
-    resolve_azure_model_name,
-)
+from typeagent.aitools.model_adapters import create_chat_model
 from typeagent.knowpro import answers, searchlang
 from typeagent.knowpro.answer_response_schema import AnswerResponse
 from typeagent.knowpro.convsettings import ConversationSettings
@@ -42,38 +36,6 @@ from typeagent.mcp.server import (
 )
 
 from conftest import EPISODE_53_INDEX
-
-
-def create_async_openai_client(
-    endpoint_envvar: str = "AZURE_OPENAI_ENDPOINT",
-    base_url: str | None = None,
-):
-    """Create AsyncOpenAI or AsyncAzureOpenAI client based on environment variables."""
-    from openai import AsyncAzureOpenAI, AsyncOpenAI
-
-    if openai_api_key := os.getenv("OPENAI_API_KEY"):
-        return AsyncOpenAI(api_key=openai_api_key, base_url=base_url, max_retries=5)
-
-    elif azure_api_key := os.getenv("AZURE_OPENAI_API_KEY"):
-        azure_api_key = get_azure_api_key(azure_api_key)
-        azure_endpoint, api_version = parse_azure_endpoint(endpoint_envvar)
-
-        apim_key = os.getenv("AZURE_APIM_SUBSCRIPTION_KEY")
-
-        return AsyncAzureOpenAI(
-            api_version=api_version,
-            azure_endpoint=azure_endpoint,
-            api_key=azure_api_key,
-            default_headers=(
-                {"Ocp-Apim-Subscription-Key": apim_key} if apim_key else None
-            ),
-            max_retries=5,
-        )
-
-    else:
-        raise RuntimeError(
-            "Neither OPENAI_API_KEY nor AZURE_OPENAI_API_KEY was provided."
-        )
 
 
 @pytest.fixture
@@ -97,49 +59,32 @@ async def sampling_callback(
     params: CreateMessageRequestParams,
 ) -> CreateMessageResult:
     """Sampling callback that uses OpenAI to generate responses."""
-    client = create_async_openai_client()
+    model = create_chat_model()
 
-    # Convert MCP SamplingMessage to OpenAI format
-    messages: list[ChatCompletionMessageParam] = []
+    # Convert MCP SamplingMessage to TypeChat PromptSection list
+    sections: list[typechat.PromptSection] = []
+    if params.systemPrompt:
+        sections.append({"role": "system", "content": params.systemPrompt})
     for msg in params.messages:
-        # Handle TextContent
-        content: str
         if isinstance(msg.content, TextContent):
             content = msg.content.text
         else:
             raise ValueError(
                 f"Unsupported content type in sampling message: {type(msg.content)}"
             )
+        role = "user" if msg.role == "user" else "assistant"
+        sections.append({"role": role, "content": content})
 
-        # MCP roles are "user" or "assistant", which are compatible with OpenAI
-        if msg.role == "user":
-            messages.append({"role": "user", "content": content})
-        else:
-            messages.append({"role": "assistant", "content": content})
+    result = await model.complete(sections)
+    if isinstance(result, typechat.Success):
+        text = result.value
+    else:
+        text = result.message
 
-    # Add system prompt if provided
-    if params.systemPrompt:
-        messages.insert(0, {"role": "system", "content": params.systemPrompt})
-
-    # Call OpenAI
-    model_name = "gpt-4o"
-    if os.getenv("AZURE_OPENAI_API_KEY") and not os.getenv("OPENAI_API_KEY"):
-        model_name = resolve_azure_model_name(model_name)
-
-    response = await client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_tokens=params.maxTokens,
-        temperature=params.temperature if params.temperature is not None else 1.0,
-    )
-
-    # Convert response to MCP format
     return CreateMessageResult(
         role="assistant",
-        content=TextContent(
-            type="text", text=response.choices[0].message.content or ""
-        ),
-        model=response.model,
+        content=TextContent(type="text", text=text),
+        model="gpt-4o",
         stopReason="endTurn",
     )
 
@@ -392,39 +337,17 @@ class TestQuestionResponseMatchDefault:
 
 
 @pytest.mark.asyncio
-async def test_sampling_callback_uses_azure_deployment_name(
+async def test_sampling_callback_delegates_to_chat_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Azure-only sampling should send the resolved deployment name."""
-    create = AsyncMock(
-        return_value=SimpleNamespace(
-            choices=[
-                SimpleNamespace(
-                    message=SimpleNamespace(content="response"),
-                )
-            ],
-            model="gpt-4o-2",
-        )
-    )
-    fake_client = SimpleNamespace(
-        chat=SimpleNamespace(
-            completions=SimpleNamespace(
-                create=create,
-            )
-        )
-    )
+    """sampling_callback should delegate to create_chat_model().complete()."""
+    fake_model = AsyncMock()
+    fake_model.complete.return_value = typechat.Success("response")
 
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "test-key")
     monkeypatch.setattr(
         sys.modules[__name__],
-        "create_async_openai_client",
-        lambda: fake_client,
-    )
-    monkeypatch.setattr(
-        sys.modules[__name__],
-        "resolve_azure_model_name",
-        lambda model_name: f"{model_name}-2",
+        "create_chat_model",
+        lambda: fake_model,
     )
 
     params = CreateMessageRequestParams(
@@ -442,13 +365,11 @@ async def test_sampling_callback_uses_azure_deployment_name(
         params,
     )
 
-    create.assert_awaited_once_with(
-        model="gpt-4o-2",
-        messages=[{"role": "user", "content": "hello"}],
-        max_tokens=32,
-        temperature=1.0,
-    )
-    assert result.model == "gpt-4o-2"
+    fake_model.complete.assert_awaited_once()
+    call_args = fake_model.complete.call_args[0][0]
+    assert call_args == [{"role": "user", "content": "hello"}]
+    assert isinstance(result.content, TextContent)
+    assert result.content.text == "response"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,6 @@ import os
 from dotenv import load_dotenv
 import pytest
 
-from openai import AsyncAzureOpenAI, AsyncOpenAI
 import pydantic.dataclasses
 import typechat
 
@@ -310,34 +309,6 @@ class TestGetAzureApiKey:
         # (lowercased) triggers that path. Since we can't call the identity provider
         # in tests, just verify non-identity keys pass through unchanged.
         assert utils.get_azure_api_key("APIKEY123") == "APIKEY123"
-
-
-class TestCreateAsyncOpenAIClient:
-    def test_no_keys_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
-        with pytest.raises(RuntimeError, match="Neither OPENAI_API_KEY"):
-            utils.create_async_openai_client()
-
-    def test_openai_key_returns_async_openai(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-        monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
-        client = utils.create_async_openai_client()
-        assert isinstance(client, AsyncOpenAI)
-
-    def test_azure_key_returns_async_azure_openai(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-key")
-        monkeypatch.setenv(
-            "AZURE_OPENAI_ENDPOINT",
-            "https://myhost.openai.azure.com/openai/deployments/gpt-4o?api-version=2025-01-01-preview",
-        )
-        client = utils.create_async_openai_client()
-        assert isinstance(client, AsyncAzureOpenAI)
 
 
 class TestMakeAgent:


### PR DESCRIPTION
The only call site was in test_mcp_server.py. Switch that to import things from model_adapters.py.