### PR TITLE
Remove dead extract_knowledge_for_text_batch_q function

### DIFF
--- a/src/typeagent/knowpro/knowledge.py
+++ b/src/typeagent/knowpro/knowledge.py
@@ -193,25 +193,3 @@ def merge_topics(topics: list[str]) -> list[str]:
     # TODO: Preserve order of first occurrence?
     merged_topics = set(topics)
     return list(merged_topics)
-
-
-async def extract_knowledge_for_text_batch_q(
-    knowledge_extractor: convknowledge.KnowledgeExtractor,
-    text_batch: list[str],
-    concurrency: int = 2,
-) -> list[Result[kplib.KnowledgeResponse]]:
-    """Extract knowledge for a batch of text inputs using a task queue."""
-    raise NotImplementedError("TODO")
-    # TODO: BatchTask etc.
-    # task_batch = [BatchTask(task=text) for text in text_batch]
-
-    # await run_in_batches(
-    #     task_batch,
-    #     lambda text: extract_knowledge_from_text(knowledge_extractor, text),
-    #     concurrency,
-    # )
-
-    # results = []
-    # for task in task_batch:
-    #     results.append(task.result if task.result else Failure("No result"))
-    # return results


### PR DESCRIPTION
## Summary

- Removes `extract_knowledge_for_text_batch_q` from `knowledge.py` — a stub that only raised `NotImplementedError` with no callers
- Spotted during review of PR #252 (bmerkle noted the `concurrency=2` default inconsistency; turns out the function is dead code)

## Test plan

- [x] All 679 tests passing