### PR TITLE
Migrate ingest_vtt.py to streaming ingestion API

### DIFF
--- a/src/typeagent/knowpro/conversation_base.py
+++ b/src/typeagent/knowpro/conversation_base.py
@@ -226,8 +226,8 @@ class ConversationBase(
         nearly doubles throughput for multi-batch ingestions.
 
         **Source-ID tracking**: each message's ``source_id`` (if not ``None``)
-        is checked before ingestion.  Already-ingested sources are silently
-        skipped.  Newly ingested sources are marked within the same transaction.
+        is marked as ingested within the commit transaction.  Callers are
+        responsible for filtering duplicates before yielding messages.
 
         **Extraction failures**: when knowledge extraction returns a
         ``Failure`` for a chunk, the failure is recorded via
@@ -258,56 +258,39 @@ class ConversationBase(
             total.messages_added += result.messages_added
             total.semrefs_added += result.semrefs_added
             total.chunks_added += result.chunks_added
-            total.messages_skipped += result.messages_skipped
             if on_batch_committed:
                 on_batch_committed(result)
 
         pending_commit: asyncio.Task[AddMessagesResult] | None = None
         pending_extraction: asyncio.Task[_ExtractionResult | None] | None = None
-        pending_skipped: int = 0
 
         async def _drain_commit() -> None:
-            nonlocal pending_commit, pending_skipped
+            nonlocal pending_commit
             if pending_commit is not None:
-                result = await pending_commit
-                result.messages_skipped += pending_skipped
-                _accumulate(result)
+                _accumulate(await pending_commit)
                 pending_commit = None
-                pending_skipped = 0
 
-        async def _submit_batch(filtered: list[TMessage], skipped: int) -> None:
-            nonlocal pending_commit, pending_extraction, pending_skipped
-            if not filtered and not skipped:
+        async def _submit_batch(batch: list[TMessage]) -> None:
+            nonlocal pending_commit, pending_extraction
+            if not batch:
                 return
 
-            if filtered and should_extract:
+            if should_extract:
                 next_extraction = asyncio.create_task(
-                    self._extract_knowledge_for_batch(filtered)
+                    self._extract_knowledge_for_batch(batch)
                 )
             else:
                 next_extraction = None
             pending_extraction = next_extraction
 
-            # Wait for previous commit to finish (frees the DB connection)
             await _drain_commit()
 
-            if not filtered:
-                # Nothing to commit, just report skipped
-                total.messages_skipped += skipped
-                if on_batch_committed:
-                    on_batch_committed(AddMessagesResult(messages_skipped=skipped))
-                return
-
-            # Await extraction result for this batch
             extraction = await next_extraction if next_extraction is not None else None
             pending_extraction = None
 
-            # Start commit (DB transaction) — runs concurrently with the
-            # *next* batch's LLM extraction once we yield back to the loop.
             pending_commit = asyncio.create_task(
-                self._commit_batch_streaming(storage, filtered, extraction)
+                self._commit_batch_streaming(storage, batch, extraction)
             )
-            pending_skipped = skipped
 
         try:
             batch: list[TMessage] = []
@@ -315,21 +298,18 @@ class ConversationBase(
             async for msg in messages:
                 msg_chunks = len(msg.text_chunks)
                 if batch and batch_chunks + msg_chunks > batch_size:
-                    filtered, skipped = await self._filter_ingested(storage, batch)
-                    await _submit_batch(filtered, skipped)
+                    await _submit_batch(batch)
                     batch = []
                     batch_chunks = 0
                 batch.append(msg)
                 batch_chunks += msg_chunks
                 if batch_chunks >= batch_size:
-                    filtered, skipped = await self._filter_ingested(storage, batch)
-                    await _submit_batch(filtered, skipped)
+                    await _submit_batch(batch)
                     batch = []
                     batch_chunks = 0
 
             if batch:
-                filtered, skipped = await self._filter_ingested(storage, batch)
-                await _submit_batch(filtered, skipped)
+                await _submit_batch(batch)
 
             await _drain_commit()
         except BaseException:
@@ -344,31 +324,6 @@ class ConversationBase(
             raise
 
         return total
-
-    async def _filter_ingested(
-        self,
-        storage: IStorageProvider[TMessage],
-        batch: list[TMessage],
-    ) -> tuple[list[TMessage], int]:
-        """Filter out messages whose source_id has already been ingested.
-
-        Returns (filtered_messages, skipped_count).
-
-        Uses a single batch query instead of per-message lookups.
-        """
-        source_ids = [m.source_id for m in batch if m.source_id is not None]
-        if source_ids:
-            ingested = await storage.are_sources_ingested(source_ids)
-        else:
-            ingested = set[str]()
-        filtered: list[TMessage] = []
-        skipped = 0
-        for msg in batch:
-            if msg.source_id is not None and msg.source_id in ingested:
-                skipped += 1
-                continue
-            filtered.append(msg)
-        return filtered, skipped
 
     async def _extract_knowledge_for_batch(
         self,

--- a/tests/test_add_messages_streaming.py
+++ b/tests/test_add_messages_streaming.py
@@ -162,29 +162,6 @@ async def test_streaming_batching() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_skips_already_ingested() -> None:
-    """Messages whose source_id is already ingested are skipped."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        transcript, storage = await _create_transcript(db_path)
-
-        # Pre-mark some sources as ingested
-        async with storage:
-            await storage.mark_source_ingested("s-1")
-            await storage.mark_source_ingested("s-3")
-
-        msgs = [_make_message(f"msg-{i}", source_id=f"s-{i}") for i in range(5)]
-        result = await transcript.add_messages_streaming(_async_iter(msgs))
-
-        # s-1 and s-3 skipped -> only 3 added
-        assert result.messages_added == 3
-        assert await transcript.messages.size() == 3
-        assert _ingested_count(storage) == 5  # 2 pre-existing + 3 new
-
-        await storage.close()
-
-
-@pytest.mark.asyncio
 async def test_streaming_no_source_id_always_ingested() -> None:
     """Messages without source_id are always ingested (never skipped)."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -274,26 +251,6 @@ async def test_streaming_empty_iterable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_all_skipped_batch() -> None:
-    """A batch where all messages are already ingested produces no commit."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        transcript, storage = await _create_transcript(db_path)
-
-        # Pre-mark all sources
-        async with storage:
-            for i in range(3):
-                await storage.mark_source_ingested(f"s-{i}")
-
-        msgs = [_make_message(f"msg-{i}", source_id=f"s-{i}") for i in range(3)]
-        result = await transcript.add_messages_streaming(_async_iter(msgs))
-
-        assert result.messages_added == 0
-        assert await transcript.messages.size() == 0
-
-        await storage.close()
-
-
 # ---------------------------------------------------------------------------
 # Pipeline overlap and DB batching tests
 # ---------------------------------------------------------------------------
@@ -664,36 +621,6 @@ async def test_streaming_multi_chunk_exception_preserves_earlier_batch() -> None
 
 
 @pytest.mark.asyncio
-async def test_streaming_multi_chunk_skip_and_ingest_mixed() -> None:
-    """Multi-chunk messages are skipped or ingested as a whole based on source_id."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        extractor = ControlledExtractor()
-        transcript, storage = await _create_transcript(
-            db_path, auto_extract=True, knowledge_extractor=extractor
-        )
-
-        # Pre-mark s-1 as ingested
-        async with storage:
-            await storage.mark_source_ingested("s-1")
-
-        msgs = [
-            _make_multi_chunk_message(["a", "b"], source_id="s-0"),  # ingested
-            _make_multi_chunk_message(["c", "d", "e"], source_id="s-1"),  # skipped
-            _make_message("f", source_id="s-2"),  # ingested
-        ]
-        result = await transcript.add_messages_streaming(_async_iter(msgs))
-
-        assert result.messages_added == 2
-        assert result.messages_skipped == 1
-        assert result.chunks_added == 3  # 2 + 1 (not 5)
-        # Only 3 extraction calls (2 chunks from s-0 + 1 chunk from s-2)
-        assert extractor.call_count == 3
-
-        await storage.close()
-
-
-@pytest.mark.asyncio
 async def test_streaming_batch_size_1_separates_all() -> None:
     """batch_size=1 commits every single-chunk message individually."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -710,38 +637,6 @@ async def test_streaming_batch_size_1_separates_all() -> None:
 
         assert result.messages_added == 4
         assert batch_results == [1, 1, 1, 1]
-
-        await storage.close()
-
-
-@pytest.mark.asyncio
-async def test_streaming_callback_reports_skipped_multi_chunk() -> None:
-    """on_batch_committed reports skipped count for batches with multi-chunk messages."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        transcript, storage = await _create_transcript(db_path)
-
-        # Pre-mark s-1 as ingested
-        async with storage:
-            await storage.mark_source_ingested("s-1")
-
-        msgs = [
-            _make_multi_chunk_message(["a", "b"], source_id="s-0"),  # 2 chunks
-            _make_multi_chunk_message(["c", "d"], source_id="s-1"),  # 2 chunks, skipped
-            _make_message("e", source_id="s-2"),  # 1 chunk → total = 5 chunks in batch
-        ]
-        callback_results: list[tuple[int, int]] = []
-        result = await transcript.add_messages_streaming(
-            _async_iter(msgs),
-            batch_size=10,  # all fit in one batch
-            on_batch_committed=lambda r: callback_results.append(
-                (r.messages_added, r.messages_skipped)
-            ),
-        )
-
-        assert result.messages_added == 2
-        assert result.messages_skipped == 1
-        assert callback_results == [(2, 1)]
 
         await storage.close()
 
@@ -775,48 +670,6 @@ async def test_streaming_preflush_avoids_oversized_batch() -> None:
         assert result.chunks_added == 12
         # Batch 1: 3 msgs × 3 chunks = 9, Batch 2: 1 msg × 3 chunks = 3
         assert batch_chunks == [9, 3]
-
-        await storage.close()
-
-
-@pytest.mark.asyncio
-async def test_streaming_all_skipped_batch_after_real_batch() -> None:
-    """A batch of all-duplicates reports skipped correctly.
-
-    First call ingests messages s-0..s-2. Second call re-submits the same
-    source_ids — they should all be filtered by _filter_ingested, exercising
-    the all-skipped + pending_commit path.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = os.path.join(tmpdir, "test.db")
-        transcript, storage = await _create_transcript(db_path)
-
-        msgs = [_make_message(f"msg-{i}", source_id=f"s-{i}") for i in range(3)]
-
-        # First call — ingest originals
-        result1 = await transcript.add_messages_streaming(
-            _async_iter(msgs),
-            batch_size=3,
-        )
-        assert result1.messages_added == 3
-        assert result1.messages_skipped == 0
-
-        # Second call — all duplicates
-        dupes = [_make_message(f"msg-{i}", source_id=f"s-{i}") for i in range(3)]
-        batch_results: list[AddMessagesResult] = []
-        result2 = await transcript.add_messages_streaming(
-            _async_iter(dupes),
-            batch_size=3,
-            on_batch_committed=lambda r: batch_results.append(r),
-        )
-
-        assert result2.messages_added == 0
-        assert result2.messages_skipped == 3
-
-        # One callback for the all-skipped batch
-        assert len(batch_results) == 1
-        assert batch_results[0].messages_added == 0
-        assert batch_results[0].messages_skipped == 3
 
         await storage.close()
 
@@ -932,8 +785,8 @@ async def test_streaming_pending_commit_cancelled_on_iterator_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_empty_batch_after_filter() -> None:
-    """Streaming with an empty iterator after a real batch returns zeros."""
+async def test_streaming_empty_iterator() -> None:
+    """Streaming with an empty iterator returns zeros."""
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test.db")
         transcript, storage = await _create_transcript(db_path)

--- a/tools/ingest_email.py
+++ b/tools/ingest_email.py
@@ -342,9 +342,6 @@ async def _email_generator(
     skip_count = 0
 
     for source_id, email_file, label in _iter_emails(eml_paths, verbose, offset, limit):
-        # Pre-parse dedup: skip before opening the file.
-        # A second dedup pass happens in _filter_ingested() to catch
-        # sources committed by an earlier batch in the same run.
         if await storage.is_source_ingested(source_id):
             counters["skipped"] += 1
             basename = email_file.name
@@ -451,7 +448,6 @@ async def ingest_emails(
     counters: dict[str, int] = {
         "parsed": 0,
         "skipped": 0,
-        "batch_skipped": 0,
         "date_skipped": 0,
         "failed": 0,
         "ingested": 0,
@@ -463,7 +459,6 @@ async def ingest_emails(
     def on_batch_committed(result: AddMessagesResult) -> None:
         nonlocal last_batch_time
         counters["ingested"] += result.messages_added
-        counters["batch_skipped"] += result.messages_skipped
         counters["chunks"] += result.chunks_added
         counters["semrefs"] += result.semrefs_added
         counters["batches"] += 1
@@ -518,7 +513,7 @@ async def ingest_emails(
     )
     total_chunks = result.chunks_added if result is not None else counters["chunks"]
     semrefs_added = result.semrefs_added if result is not None else counters["semrefs"]
-    total_skipped = counters["skipped"] + counters["batch_skipped"]
+    total_skipped = counters["skipped"]
     overall_per_chunk = elapsed / total_chunks if total_chunks else 0
 
     print()

--- a/tools/ingest_vtt.py
+++ b/tools/ingest_vtt.py
@@ -15,6 +15,7 @@ Usage:
 
 import argparse
 import asyncio
+from collections.abc import AsyncIterator
 from datetime import timedelta
 import os
 from pathlib import Path
@@ -27,6 +28,7 @@ import webvtt
 from typeagent.aitools.model_adapters import create_embedding_model
 from typeagent.knowpro.convsettings import ConversationSettings
 from typeagent.knowpro.interfaces import ConversationMetadata
+from typeagent.knowpro.interfaces_core import AddMessagesResult
 from typeagent.knowpro.universal_message import format_timestamp_utc, UNIX_EPOCH
 from typeagent.storage.utils import create_storage_provider
 from typeagent.transcripts.transcript import (
@@ -82,6 +84,13 @@ def create_arg_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of chunks per commit batch (default: 100)",
+    )
+
+    parser.add_argument(
         "--embedding-name",
         type=str,
         default=None,
@@ -133,6 +142,7 @@ async def ingest_vtt_files(
     merge_consecutive: bool = False,
     verbose: bool = False,
     concurrency: int | None = None,
+    batch_size: int = 100,
     embedding_name: str | None = None,
 ) -> None:
     """Ingest one or more VTT files into a database."""
@@ -254,110 +264,106 @@ async def ingest_vtt_files(
             )
             sys.exit(1)
 
-        # Process all VTT files and collect messages
-        all_messages: list[TranscriptMessage] = []
-        time_offset = 0.0  # Cumulative time offset for multiple files
+        msg_count = [0]  # mutable counter shared with the generator
 
-        for file_idx, vtt_file in enumerate(vtt_files):
-            if verbose:
-                print(f"  Processing {vtt_file}...")
-                if file_idx > 0:
-                    print(f"    Time offset: {time_offset:.2f} seconds")
+        async def _message_stream() -> AsyncIterator[TranscriptMessage]:
+            time_offset = 0.0
 
-            # Parse VTT file
-            try:
-                vtt = webvtt.read(vtt_file)
-            except Exception as e:
-                print(
-                    f"Error: Failed to parse VTT file {vtt_file}: {e}", file=sys.stderr
-                )
-                sys.exit(1)
+            for file_idx, vtt_file in enumerate(vtt_files):
+                if verbose:
+                    print(f"  Processing {vtt_file}...")
+                    if file_idx > 0:
+                        print(f"    Time offset: {time_offset:.2f} seconds")
 
-            current_speaker = None
-            current_text_chunks = []
-            current_start_time = None
-            file_max_end_time = 0.0  # Track the maximum end time in this file
+                try:
+                    vtt = webvtt.read(vtt_file)
+                except Exception as e:
+                    print(
+                        f"Error: Failed to parse VTT file {vtt_file}: {e}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
 
-            def save_current_message():
-                """Helper to save the current message and add to all_messages."""
-                if current_text_chunks and current_start_time is not None:
-                    combined_text = " ".join(current_text_chunks).strip()
-                    if combined_text:
-                        # Calculate timestamp from WebVTT start time
-                        offset_seconds = webvtt_timestamp_to_seconds(current_start_time)
-                        timestamp = format_timestamp_utc(
-                            UNIX_EPOCH + timedelta(seconds=offset_seconds)
-                        )
-                        metadata = TranscriptMessageMeta(
-                            speaker=current_speaker,
-                            recipients=[],
-                        )
-                        message = TranscriptMessage(
-                            text_chunks=[combined_text],
-                            metadata=metadata,
-                            timestamp=timestamp,
-                        )
-                        all_messages.append(message)
+                current_speaker: str | None = None
+                current_text_chunks: list[str] = []
+                current_start_time: str | None = None
+                file_max_end_time = 0.0
 
-            for caption in vtt:
-                # Skip empty captions
-                if not caption.text.strip():
-                    continue
+                def _build_message() -> TranscriptMessage | None:
+                    if current_text_chunks and current_start_time is not None:
+                        combined_text = " ".join(current_text_chunks).strip()
+                        if combined_text:
+                            offset_seconds = webvtt_timestamp_to_seconds(
+                                current_start_time
+                            )
+                            timestamp = format_timestamp_utc(
+                                UNIX_EPOCH + timedelta(seconds=offset_seconds)
+                            )
+                            metadata = TranscriptMessageMeta(
+                                speaker=current_speaker,
+                                recipients=[],
+                            )
+                            return TranscriptMessage(
+                                text_chunks=[combined_text],
+                                metadata=metadata,
+                                timestamp=timestamp,
+                                source_id=f"{vtt_file}#{msg_count[0]}",
+                            )
+                    return None
 
-                # Parse raw text for voice tags (handles multiple speakers per cue)
-                raw_text = getattr(caption, "raw_text", caption.text)
-                voice_segments = parse_voice_tags(raw_text)
-
-                # Convert WebVTT timestamps and apply offset for multi-file continuity
-                start_time_seconds = (
-                    vtt_timestamp_to_seconds(caption.start) + time_offset
-                )
-                end_time_seconds = vtt_timestamp_to_seconds(caption.end) + time_offset
-                start_time = seconds_to_vtt_timestamp(start_time_seconds)
-
-                # Track the maximum end time for this file
-                if end_time_seconds > file_max_end_time:
-                    file_max_end_time = end_time_seconds
-
-                # Process each voice segment in this caption
-                for speaker, text in voice_segments:
-                    if not text.strip():
+                for caption in vtt:
+                    if not caption.text.strip():
                         continue
 
-                    # If we should merge consecutive segments from the same speaker
-                    if (
-                        merge_consecutive
-                        and speaker == current_speaker
-                        and current_text_chunks
-                    ):
-                        # Merge with current message
-                        current_text_chunks.append(text)
-                    else:
-                        # Save previous message if it exists
-                        save_current_message()
+                    raw_text = getattr(caption, "raw_text", caption.text)
+                    voice_segments = parse_voice_tags(raw_text)
 
-                        # Start new message
-                        current_speaker = speaker
-                        current_text_chunks = [text] if text.strip() else []
-                        current_start_time = start_time
-
-            # Don't forget the last message from this file
-            save_current_message()
-
-            if verbose:
-                print(f"    Extracted {len(all_messages)} messages so far")
-                if file_max_end_time > 0:
-                    print(
-                        f"    File time range: 0.00s to {file_max_end_time - time_offset:.2f}s (with offset: {time_offset:.2f}s to {file_max_end_time:.2f}s)"
+                    start_time_seconds = (
+                        vtt_timestamp_to_seconds(caption.start) + time_offset
                     )
+                    end_time_seconds = (
+                        vtt_timestamp_to_seconds(caption.end) + time_offset
+                    )
+                    start_time = seconds_to_vtt_timestamp(start_time_seconds)
 
-            # Update time offset for next file: add 5 seconds gap
-            if file_max_end_time > 0:
-                time_offset = file_max_end_time + 5.0
+                    if end_time_seconds > file_max_end_time:
+                        file_max_end_time = end_time_seconds
 
-        # Add all messages to the database in batches with indexing
-        if verbose:
-            print(f"\nAdding {len(all_messages)} total messages to database...")
+                    for speaker, text in voice_segments:
+                        if not text.strip():
+                            continue
+
+                        if (
+                            merge_consecutive
+                            and speaker == current_speaker
+                            and current_text_chunks
+                        ):
+                            current_text_chunks.append(text)
+                        else:
+                            msg = _build_message()
+                            if msg is not None:
+                                msg_count[0] += 1
+                                yield msg
+
+                            current_speaker = speaker
+                            current_text_chunks = [text] if text.strip() else []
+                            current_start_time = start_time
+
+                # Last message from this file
+                msg = _build_message()
+                if msg is not None:
+                    msg_count[0] += 1
+                    yield msg
+
+                if verbose:
+                    print(f"    Extracted {msg_count[0]} messages so far")
+                    if file_max_end_time > 0:
+                        print(
+                            f"    File time range: 0.00s to {file_max_end_time - time_offset:.2f}s (with offset: {time_offset:.2f}s to {file_max_end_time:.2f}s)"
+                        )
+
+                if file_max_end_time > 0:
+                    time_offset = file_max_end_time + 5.0
 
         try:
             # Enable knowledge extraction for index building
@@ -378,43 +384,100 @@ async def ingest_vtt_files(
                 tags=[name, "vtt-transcript"],
             )
 
-            # Process messages in batches for recoverability
-            batch_size = 50
-            successful_count = 0
             start_time = time.time()
+            last_batch_time = start_time
+
+            counters: dict[str, int] = {
+                "ingested": 0,
+                "skipped": 0,
+                "chunks": 0,
+                "semrefs": 0,
+                "batches": 0,
+            }
+
+            def on_batch_committed(result: AddMessagesResult) -> None:
+                nonlocal last_batch_time
+                counters["ingested"] += result.messages_added
+                counters["skipped"] += result.messages_skipped
+                counters["chunks"] += result.chunks_added
+                counters["semrefs"] += result.semrefs_added
+                counters["batches"] += 1
+                now = time.time()
+                batch_secs = now - last_batch_time
+                last_batch_time = now
+                elapsed = now - start_time
+                per_chunk = (
+                    batch_secs / result.chunks_added if result.chunks_added else 0
+                )
+                parts = [
+                    f"    {counters['ingested']} messages",
+                    f"+{result.chunks_added} chunks",
+                    f"+{result.semrefs_added} semrefs",
+                ]
+                if result.messages_skipped:
+                    parts.append(f"{result.messages_skipped} skipped")
+                print(
+                    f"{' | '.join(parts)} | "
+                    f"{batch_secs:.1f}s ({per_chunk:.2f}s/chunk) | "
+                    f"{elapsed:.1f}s elapsed",
+                    flush=True,
+                )
 
             print(
-                f"  Processing {len(all_messages)} messages"
+                f"  Processing messages in batches of {batch_size}"
                 f" (concurrency={settings.semantic_ref_index_settings.concurrency})..."
             )
 
-            for i in range(0, len(all_messages), batch_size):
-                batch = all_messages[i : i + batch_size]
-                batch_start = time.time()
-
-                result = await transcript.add_messages_with_indexing(batch)
-
-                successful_count += result.messages_added
-                batch_time = time.time() - batch_start
-
-                elapsed = time.time() - start_time
-                print(
-                    f"    {successful_count}/{len(all_messages)} messages | "
-                    f"{await semref_coll.size()} refs | "
-                    f"{batch_time:.1f}s/batch | "
-                    f"{elapsed:.1f}s elapsed"
+            result: AddMessagesResult | None = None
+            interrupted = False
+            try:
+                result = await transcript.add_messages_streaming(
+                    _message_stream(),
+                    batch_size=batch_size,
+                    on_batch_committed=on_batch_committed,
                 )
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                interrupted = True
+
+            elapsed = time.time() - start_time
+            if interrupted and counters["batches"] == 0:
+                print()
+                print("Interrupted before any batches were committed.")
+                return
+
+            messages_ingested = (
+                result.messages_added if result is not None else counters["ingested"]
+            )
+            total_chunks = (
+                result.chunks_added if result is not None else counters["chunks"]
+            )
+            semrefs_added = (
+                result.semrefs_added if result is not None else counters["semrefs"]
+            )
+            total_skipped = counters["skipped"]
+            overall_per_chunk = elapsed / total_chunks if total_chunks else 0
 
             if verbose:
-                semref_count = await semref_coll.size()
-                print(f"  Successfully added {successful_count} messages")
-                print(f"  Extracted {semref_count} semantic references")
+                if interrupted:
+                    print("Ingestion interrupted by user (^C).")
+                print(f"  Successfully added {messages_ingested} messages")
+                print(f"  Ingested {total_chunks} chunk(s)")
+                if total_skipped:
+                    print(f"  Skipped {total_skipped} already-ingested message(s)")
+                print(f"  Extracted {semrefs_added} semantic references")
+                print(f"  Total time: {elapsed:.1f}s")
+                print(f"  Overall time per chunk: {overall_per_chunk:.2f}s/chunk")
             else:
                 print(
-                    f"Imported {successful_count} messages from {len(vtt_files)} file(s) to {database}"
+                    f"Imported {messages_ingested} messages from {len(vtt_files)} file(s) to {database}"
+                    f" ({total_chunks} chunks, {semrefs_added} refs, {elapsed:.1f}s,"
+                    f" {overall_per_chunk:.2f}s/chunk)"
                 )
+                if total_skipped:
+                    print(f"Skipped: {total_skipped} (already ingested)")
 
-            print("All indexes built successfully")
+            if not interrupted:
+                print("All indexes built successfully")
 
         except BaseException as e:
             print(f"\nError: Failed to process messages: {e}", file=sys.stderr)
@@ -451,6 +514,7 @@ def main():
             name=args.name,
             merge_consecutive=args.merge,
             concurrency=args.concurrency,
+            batch_size=args.batch_size,
             embedding_name=args.embedding_name,
             verbose=args.verbose,
         )

--- a/tools/ingest_vtt.py
+++ b/tools/ingest_vtt.py
@@ -264,9 +264,10 @@ async def ingest_vtt_files(
             )
             sys.exit(1)
 
-        msg_count = [0]  # mutable counter shared with the generator
+        msg_count = 0
 
         async def _message_stream() -> AsyncIterator[TranscriptMessage]:
+            nonlocal msg_count
             time_offset = 0.0
 
             for file_idx, vtt_file in enumerate(vtt_files):
@@ -307,7 +308,7 @@ async def ingest_vtt_files(
                                 text_chunks=[combined_text],
                                 metadata=metadata,
                                 timestamp=timestamp,
-                                source_id=f"{vtt_file}#{msg_count[0]}",
+                                source_id=f"{vtt_file}#{msg_count}",
                             )
                     return None
 
@@ -342,7 +343,7 @@ async def ingest_vtt_files(
                         else:
                             msg = _build_message()
                             if msg is not None:
-                                msg_count[0] += 1
+                                msg_count += 1
                                 yield msg
 
                             current_speaker = speaker
@@ -352,15 +353,8 @@ async def ingest_vtt_files(
                 # Last message from this file
                 msg = _build_message()
                 if msg is not None:
-                    msg_count[0] += 1
+                    msg_count += 1
                     yield msg
-
-                if verbose:
-                    print(f"    Extracted {msg_count[0]} messages so far")
-                    if file_max_end_time > 0:
-                        print(
-                            f"    File time range: 0.00s to {file_max_end_time - time_offset:.2f}s (with offset: {time_offset:.2f}s to {file_max_end_time:.2f}s)"
-                        )
 
                 if file_max_end_time > 0:
                     time_offset = file_max_end_time + 5.0

--- a/tools/ingest_vtt.py
+++ b/tools/ingest_vtt.py
@@ -383,7 +383,6 @@ async def ingest_vtt_files(
 
             counters: dict[str, int] = {
                 "ingested": 0,
-                "skipped": 0,
                 "chunks": 0,
                 "semrefs": 0,
                 "batches": 0,
@@ -392,7 +391,6 @@ async def ingest_vtt_files(
             def on_batch_committed(result: AddMessagesResult) -> None:
                 nonlocal last_batch_time
                 counters["ingested"] += result.messages_added
-                counters["skipped"] += result.messages_skipped
                 counters["chunks"] += result.chunks_added
                 counters["semrefs"] += result.semrefs_added
                 counters["batches"] += 1
@@ -408,8 +406,6 @@ async def ingest_vtt_files(
                     f"+{result.chunks_added} chunks",
                     f"+{result.semrefs_added} semrefs",
                 ]
-                if result.messages_skipped:
-                    parts.append(f"{result.messages_skipped} skipped")
                 print(
                     f"{' | '.join(parts)} | "
                     f"{batch_secs:.1f}s ({per_chunk:.2f}s/chunk) | "
@@ -448,7 +444,6 @@ async def ingest_vtt_files(
             semrefs_added = (
                 result.semrefs_added if result is not None else counters["semrefs"]
             )
-            total_skipped = counters["skipped"]
             overall_per_chunk = elapsed / total_chunks if total_chunks else 0
 
             if verbose:
@@ -456,8 +451,6 @@ async def ingest_vtt_files(
                     print("Ingestion interrupted by user (^C).")
                 print(f"  Successfully added {messages_ingested} messages")
                 print(f"  Ingested {total_chunks} chunk(s)")
-                if total_skipped:
-                    print(f"  Skipped {total_skipped} already-ingested message(s)")
                 print(f"  Extracted {semrefs_added} semantic references")
                 print(f"  Total time: {elapsed:.1f}s")
                 print(f"  Overall time per chunk: {overall_per_chunk:.2f}s/chunk")
@@ -467,8 +460,6 @@ async def ingest_vtt_files(
                     f" ({total_chunks} chunks, {semrefs_added} refs, {elapsed:.1f}s,"
                     f" {overall_per_chunk:.2f}s/chunk)"
                 )
-                if total_skipped:
-                    print(f"Skipped: {total_skipped} (already ingested)")
 
             if not interrupted:
                 print("All indexes built successfully")


### PR DESCRIPTION
## Summary

**Streaming migration** (commit 1):
- Replaces the manual `add_messages_with_indexing` batch loop with `add_messages_streaming`, matching the pattern already used by `ingest_email.py` and `podcast_ingest.py`
- Lazy async generator yields `TranscriptMessage` directly from the VTT parsing loop — no intermediate list allocation
- Adds `source_id` per message (`{vtt_file}#{index}`) for restartability and dedup
- Adds `--batch-size` (default 100) and `--concurrency` CLI arguments
- `on_batch_committed` callback reports per-batch chunks, semrefs, and timing
- Graceful `^C` handling — committed batches survive interruption

**Review feedback** (commit 2):
- Replaced `msg_count = [0]` list trick with `nonlocal` (per Guido's review)
- Removed verbose prints from inside the async generator that raced with batch callback output

**Dead code cleanup** (commit 3):
- Removed dead `messages_skipped` tracking (always 0 since #271 removed framework dedup)

All three ingest tools now use the same streaming pattern.

## Stack

**This PR is stacked on #271. Merge order: #271 → #267 → #268**

| # | PR | Branch | Description |
|---|---|---|---|
| 1 | #271 | `fix/remove-filter-ingested` | Remove framework dedup |
| 2 | **#267** (this) | `feat/vtt-streaming-ingestion` | VTT streaming migration |
| 3 | #268 | `refactor/email-dedup-consolidation` | Email bulk dedup |

## Reproducible test (Parrot Sketch VTT, ships in repo)

```
uv run python tools/ingest_vtt.py tests/testdata/Parrot_Sketch.vtt -d /tmp/parrot.db -v --batch-size 20
```

| Metric | Value |
|--------|-------|
| Messages | 76 (5 speakers) |
| Batches | 4 (batch-size 20) |
| Chunks | 76 |
| Semrefs | 612 |
| Total time | 67.5s |
| Per chunk | 0.89s |

## ^C interrupt test

```
uv run python tools/ingest_vtt.py tests/testdata/Parrot_Sketch.vtt -d /tmp/ctrl_c.db -v --batch-size 10
# send SIGINT after 2 batches
```

Output after ^C:
```
Ingestion interrupted by user (^C).
  Successfully added 20 messages
  Ingested 20 chunk(s)
  Extracted 188 semantic references
```

DB verification: 20 messages, 188 semrefs, 20 ingested sources — exactly the 2 committed batches.

## Test plan

- [x] `make format check test` passes (696 tests, 0 pyright errors)
- [x] Manual test: ingest a VTT file, verify progress callback output (see above)
- [x] Manual test: interrupt with ^C mid-ingestion, verify partial data committed (see above)