### PR TITLE
chore(ci): fix CI pipeline security issues reported by zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   #     - name: Get User Permission
   #       if: ${{ github.event_name == 'pull_request_target' || github.triggering_actor != 'github-merge-queue[bot]' }}
   #       id: checkAccess
-  #       uses: actions-cool/check-user-permission@v2
+  #       uses: actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e # v2.4.0
   #       with:
   #         require: write
   #         username: ${{ github.triggering_actor }}
@@ -60,17 +60,20 @@ jobs:
     name: ${{ matrix.os }} check (py ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.14"
 
       - name: Run Check (Linux)
         if: runner.os == 'Linux'
@@ -98,17 +101,20 @@ jobs:
     name: ${{ matrix.os }} format (py ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.14"
 
       - name: Run Format (Linux)
         if: runner.os == 'Linux'
@@ -134,17 +140,20 @@ jobs:
     name: ${{ matrix.os }} (py ${{ matrix.python-version }})
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.14"
 
       - name: Run Test (Linux)
         if: runner.os == 'Linux'
@@ -170,17 +179,19 @@ jobs:
   #   name: ${{ matrix.os }} (py ${{ matrix.python-version }})
 
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   #       with:
   #         ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
   #     - name: Set up Python
-  #       uses: actions/setup-python@v5
+  #       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
   #       with:
   #         python-version: ${{ matrix.python-version }}
 
   #     - name: Install uv
-  #       uses: astral-sh/setup-uv@v7
+  #       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+  #       with:
+  #         version: "0.11.14"
 
   #     - name: Install Dependencies (Linux)
   #       if: runner.os == 'Linux'
@@ -194,7 +205,7 @@ jobs:
   #           make sync
 
   #     - name: Login to Azure
-  #       uses: azure/login@v2.2.0
+  #       uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
   #       with:
   #         client-id: ${{ secrets.AZURE_CLIENTID }}
   #         tenant-id: ${{ secrets.AZURE_TENANTID }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -71,7 +73,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -100,6 +102,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -19,17 +19,20 @@ jobs:
         shell: bash
         working-directory: .     # your project subdir
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.14"
+          enable-cache: false
 
       - name: Create .venv and install deps
         run: uv sync
@@ -38,7 +41,7 @@ jobs:
         run: make build                   # runs `uv build`, outputs to dist/
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -53,13 +56,13 @@ jobs:
       id-token: write     # REQUIRED for Trusted Publishing (no tokens!)
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         # For TestPyPI first, add:
         # with:
         #   repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Description

Fixes CI pipeline security issues reported by [zizmor](https://docs.zizmor.sh/)

<details>
<summary>zizmor output (before)</summary>

```text
$ zizmor .

 INFO zizmor: 🌈 zizmor v1.24.1
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/codeql.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release-py.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/ci.yml:63:9
   |
63 |         - uses: actions/checkout@v4
   |  _________^
64 | |         with:
65 | |           ref: ${{ github.event.pull_request.head.sha || github.ref }}
   | |______________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:101:9
    |
101 |         - uses: actions/checkout@v4
    |  _________^
102 | |         with:
103 | |           ref: ${{ github.event.pull_request.head.sha || github.ref }}
    | |______________________________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/ci.yml:137:9
    |
137 |         - uses: actions/checkout@v4
    |  _________^
138 | |         with:
139 | |           ref: ${{ github.event.pull_request.head.sha || github.ref }}
    | |______________________________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/ci.yml:63:15
   |
63 |       - uses: actions/checkout@v4
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/ci.yml:68:15
   |
68 |         uses: actions/setup-python@v5
   |               ^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/ci.yml:73:15
   |
73 |         uses: astral-sh/setup-uv@v7
   |               ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/ci.yml:101:15
    |
101 |       - uses: actions/checkout@v4
    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/ci.yml:106:15
    |
106 |         uses: actions/setup-python@v5
    |               ^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/ci.yml:111:15
    |
111 |         uses: astral-sh/setup-uv@v7
    |               ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/ci.yml:137:15
    |
137 |       - uses: actions/checkout@v4
    |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/ci.yml:142:15
    |
142 |         uses: actions/setup-python@v5
    |               ^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/ci.yml:147:15
    |
147 |         uses: astral-sh/setup-uv@v7
    |               ^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/codeql.yml:63:7
   |
63 |       - name: Checkout repository
   |  _______^
64 | |       uses: actions/checkout@v4
65 | |
66 | |     # Add any setup steps before running the `github/codeql-action/init` action.
...  |
72 | |     # Initializes the CodeQL tools for scanning.
   | |________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/codeql.yml:64:13
   |
64 |       uses: actions/checkout@v4
   |             ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/codeql.yml:74:13
   |
74 |       uses: github/codeql-action/init@v4
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/codeql.yml:103:13
    |
103 |       uses: github/codeql-action/analyze@v4
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/release-py.yml:22:9
   |
22 |       - uses: actions/checkout@v4
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/release-py.yml:22:15
   |
22 |       - uses: actions/checkout@v4
   |               ^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/release-py.yml:25:15
   |
25 |         uses: actions/setup-python@v5
   |               ^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/release-py.yml:41:15
   |
41 |         uses: actions/upload-artifact@v4
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/release-py.yml:56:15
   |
56 |       - uses: actions/download-artifact@v4
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/release-py.yml:62:15
   |
62 |         uses: pypa/gh-action-pypi-publish@release/v1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

30 findings (8 suppressed, 5 fixable): 0 informational, 0 low, 5 medium, 17 high
```
</details>

<details>
<summary>zizmor output (After PR changes)</summary>

```text
$ zizmor .

 INFO zizmor: 🌈 zizmor v1.24.1
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ci.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/codeql.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/release-py.yml
No findings to report. Good job! (8 suppressed)
```

</details>