### PR TITLE
Format 0.0 facet values consistently with other floats

### DIFF
--- a/src/typeagent/storage/memory/propindex.py
+++ b/src/typeagent/storage/memory/propindex.py
@@ -45,7 +45,7 @@ async def add_facet(
         value = facet.value
         if value is not None:
             # If the value is a float, we use .g format store it as a string.
-            if isinstance(value, float) and value:
+            if isinstance(value, float):
                 value = f"{value:g}"
             await property_index.add_property(
                 PropertyNames.FacetValue.value,
@@ -122,7 +122,7 @@ def collect_facet_properties(
     ]
     value = facet.value
     if value is not None:
-        if isinstance(value, float) and value:
+        if isinstance(value, float):
             value = f"{value:g}"
         props.append((PropertyNames.FacetValue.value, str(value), ordinal))
     return props

--- a/tests/test_propindex.py
+++ b/tests/test_propindex.py
@@ -52,6 +52,27 @@ async def test_add_facet(property_index: PropertyIndex):
 
 
 @pytest.mark.asyncio
+async def test_add_facet_float_value(property_index: PropertyIndex):
+    """Float facet values use :g formatting, including 0.0 (stored as "0")."""
+    await add_facet(Facet(name="score", value=0.0), property_index, 1)
+    await add_facet(Facet(name="score", value=2.0), property_index, 2)
+
+    # 0.0 is a float like any other, so it should be stored as "0", not "0.0".
+    assert (
+        await property_index.lookup_property(PropertyNames.FacetValue.value, "0")
+        is not None
+    )
+    assert (
+        await property_index.lookup_property(PropertyNames.FacetValue.value, "0.0")
+        is None
+    )
+    assert (
+        await property_index.lookup_property(PropertyNames.FacetValue.value, "2")
+        is not None
+    )
+
+
+@pytest.mark.asyncio
 async def test_add_entity_properties_to_index(property_index: PropertyIndex):
     """Test adding entity properties to the property index."""
     entity = ConcreteEntity(


### PR DESCRIPTION
When indexing a facet whose value is a float, the code formats it with `:g`, but the guard is `isinstance(value, float) and value` — the `and value` skips `0.0` (it's falsy), so a facet value of `0.0` gets stored as `"0.0"` while every other float uses `:g` (e.g. `2.0` -> `"2"`). The comment right above says "If the value is a float, we use .g format", so the extra truthiness check looks unintended.

Dropped `and value` in the two places that do this (`add_facet` and `collect_facet_properties`) so `0.0` is formatted like any other float (`"0"`). Added a small test. Full offline test suite still passes.