### PR TITLE
Fix date-only range end dropping the final day

### DIFF
--- a/src/typeagent/knowpro/searchlang.py
+++ b/src/typeagent/knowpro/searchlang.py
@@ -670,7 +670,7 @@ def date_range_from_datetime_range(date_time_range: DateTimeRange) -> DateRange:
     return DateRange(
         start=datetime_from_date_time(date_time_range.start_date),
         end=(
-            datetime_from_date_time(date_time_range.stop_date)
+            stop_datetime_from_date_time(date_time_range.stop_date)
             if date_time_range.stop_date
             else None
         ),
@@ -690,6 +690,24 @@ def datetime_from_date_time(date_time: DateTime) -> Datetime:
         tzinfo=datetime.timezone.utc,
     )
     return dt
+
+
+def stop_datetime_from_date_time(date_time: DateTime) -> Datetime:
+    # Mirror of the TypeScript `toStopDate`: a date given without a time spans
+    # the whole day, so the (inclusive) end of the range is the end of that day
+    # rather than its midnight start -- otherwise the final day is excluded.
+    if date_time.time is not None:
+        return datetime_from_date_time(date_time)
+    return Datetime(
+        year=date_time.date.year,
+        month=date_time.date.month,
+        day=date_time.date.day,
+        hour=23,
+        minute=59,
+        second=59,
+        microsecond=999999,
+        tzinfo=datetime.timezone.utc,
+    )
 
 
 # TODO: Move to searchquerytranslator.py?

--- a/tests/test_searchlang_compile.py
+++ b/tests/test_searchlang_compile.py
@@ -182,6 +182,33 @@ class TestDateRangeFromDatetimeRange:
         assert dr.end.month == 12
         assert dr.end.day == 31
 
+    def test_date_only_stop_covers_whole_day(self) -> None:
+        # A stop date with no time should cover the whole day (end-of-day),
+        # matching the TS toStopDate. Otherwise the inclusive range drops the
+        # final requested day.
+        dtr = DateTimeRange(
+            start_date=DateTime(date=DateVal(day=1, month=1, year=2023)),
+            stop_date=DateTime(date=DateVal(day=5, month=1, year=2023)),
+        )
+        dr = date_range_from_datetime_range(dtr)
+        assert dr.end is not None
+        assert (dr.end.hour, dr.end.minute, dr.end.second) == (23, 59, 59)
+        on_last_day = datetime.datetime(2023, 1, 5, 9, 30, tzinfo=datetime.timezone.utc)
+        assert on_last_day in dr
+
+    def test_stop_with_time_is_honored(self) -> None:
+        # An explicit time on the stop date must be kept, not pushed to end-of-day.
+        dtr = DateTimeRange(
+            start_date=DateTime(date=DateVal(day=1, month=1, year=2023)),
+            stop_date=DateTime(
+                date=DateVal(day=5, month=1, year=2023),
+                time=TimeVal(hour=10, minute=0, seconds=0),
+            ),
+        )
+        dr = date_range_from_datetime_range(dtr)
+        assert dr.end is not None
+        assert (dr.end.hour, dr.end.minute) == (10, 0)
+
 
 # ---------------------------------------------------------------------------
 # compile_search_query (standalone function)


### PR DESCRIPTION
When a search time range has a stop date with no time, the compiled `DateRange` end lands at midnight (00:00:00). But `DateRange.end` is inclusive, so a query like "Jan 1 to Jan 5" produces `end = 2023-01-05 00:00:00`, and anything happening on Jan 5 after midnight falls outside the range — the whole final day is effectively dropped.

```python
dtr = DateTimeRange(
    start_date=DateTime(date=DateVal(day=1, month=1, year=2023)),
    stop_date=DateTime(date=DateVal(day=5, month=1, year=2023)),
)
dr = date_range_from_datetime_range(dtr)
# before: dr.end == 2023-01-05 00:00:00 -> an event at 2023-01-05 09:30 is NOT in dr
```

The TypeScript original uses two helpers: `toStartDate` (midnight for a date-only value) for the start, and `toStopDate` (end-of-day, `23:59:59.999`) for the stop. The Python port used the start-of-day conversion for both, so the end-of-day behavior was lost.

This adds a `stop_datetime_from_date_time` helper mirroring `toStopDate`: a date-only stop now covers the whole day (`23:59:59.999999`), while an explicit time is still honored as-is. Added tests for both cases; the full offline test suite passes.