### PR TITLE
Update AGENTS.md date/time guidance, bump pyright, minor cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ AGENTS.md. In all cases show what you added to AGENTS.md.
 - Avoid potential import cycles between conversation orchestration and pipeline modules by using neutral payload protocols/arguments instead of importing concrete pipeline result classes across modules.
 - Prefer ordinal type aliases (e.g., `MessageOrdinal`, `ChunkOrdinal`) over raw `int` in pipeline code for readability.
 - When the user asks to "fix the test only", update tests/mocks first and avoid adding production compatibility fallbacks unless explicitly requested.
+- For date/time range handling, use the half-open interval convention `[start, stop)` (stop is exclusive), as agreed in PR #198 — this avoids the ambiguity of an inclusive end (e.g. does "end of day" mean 00:00:00 or 23:59:59.999999?). Prefer this over inclusive-end ranges even when padding the end to end-of-day would also work.
 
 ## Package Management with uv
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.10,<0.11.0"]
+requires = ["uv_build>=0.9.10,<0.12.0"]
 build-backend = "uv_build"
 
 [project]
@@ -96,7 +96,7 @@ dev = [
   "logfire>=4.32.1",  # So 'make check' passes
   "msgraph-sdk>=1.56.0",
   "opentelemetry-instrumentation-httpx>=0.61b0",
-  "pyright>=1.1.409",
+  "pyright>=1.1.411",
   "pytest>=9.0.3",
   "pytest-asyncio>=1.3.0",
   "pytest-mock>=3.15.1",

--- a/src/typeagent/knowpro/answers.py
+++ b/src/typeagent/knowpro/answers.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License.
 
 import asyncio
-import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+import os
 from typing import Any
 
 import typechat

--- a/uv.lock
+++ b/uv.lock
@@ -1955,15 +1955,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -2505,7 +2505,7 @@ dev = [
     { name = "logfire", specifier = ">=4.32.1" },
     { name = "msgraph-sdk", specifier = ">=1.56.0" },
     { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.61b0" },
-    { name = "pyright", specifier = ">=1.1.409" },
+    { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },


### PR DESCRIPTION
## Summary
- Document the half-open `[start, stop)` interval convention for date/time range handling in AGENTS.md (agreed in #198)
- Bump pyright dependency to 1.1.411 and widen the `uv_build` requirement to `<0.12.0`
- Minor import reordering in `src/typeagent/knowpro/answers.py`

## Test plan
- [ ] `make check` / `pytest` pass with the updated pyright version