### PR TITLE
Replace kplib alias with direct knowledge_schema symbol imports

### DIFF
--- a/src/typeagent/emails/email_message.py
+++ b/src/typeagent/emails/email_message.py
@@ -7,9 +7,9 @@ from typing import Any
 from pydantic import Field
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
-from ..knowpro import knowledge_schema as kplib
 from ..knowpro.field_helpers import CamelCaseField
 from ..knowpro.interfaces import IKnowledgeSource, IMessage, IMessageMetadata
+from ..knowpro.knowledge_schema import Action, ConcreteEntity, Facet, KnowledgeResponse
 
 
 @pydantic_dataclass
@@ -31,16 +31,16 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
     def dest(self) -> str | list[str] | None:  # type: ignore[reportIncompatibleVariableOverride]
         return self.recipients
 
-    def get_knowledge(self) -> kplib.KnowledgeResponse:
-        return kplib.KnowledgeResponse(
+    def get_knowledge(self) -> KnowledgeResponse:
+        return KnowledgeResponse(
             entities=self.to_entities(),
             actions=self.to_actions(),
             inverse_actions=[],
             topics=self.to_topics(),
         )
 
-    def to_entities(self) -> list[kplib.ConcreteEntity]:
-        entities: list[kplib.ConcreteEntity] = []
+    def to_entities(self) -> list[ConcreteEntity]:
+        entities: list[ConcreteEntity] = []
 
         if self.sender:
             entities.extend(self._email_address_to_entities(self.sender))
@@ -57,7 +57,7 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
             for bcc in self.bcc:
                 entities.extend(self._email_address_to_entities(bcc))
 
-        entities.append(kplib.ConcreteEntity(name="email", type=["message"]))
+        entities.append(ConcreteEntity(name="email", type=["message"]))
         return entities
 
     def to_topics(self) -> list[str]:
@@ -66,8 +66,8 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
             topics.append(self.subject)
         return topics
 
-    def to_actions(self) -> list[kplib.Action]:
-        actions: list[kplib.Action] = []
+    def to_actions(self) -> list[Action]:
+        actions: list[Action] = []
         if self.sender and self.recipients:
             for recipient in self.recipients:
                 actions.extend(self._create_actions("sent", self.sender, recipient))
@@ -75,19 +75,17 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
         return actions
 
     # Returns the knowledge entities for a given email address string
-    def _email_address_to_entities(
-        self, email_address: str
-    ) -> list[kplib.ConcreteEntity]:
-        entities: list[kplib.ConcreteEntity] = []
+    def _email_address_to_entities(self, email_address: str) -> list[ConcreteEntity]:
+        entities: list[ConcreteEntity] = []
         display_name, address = parseaddr(email_address)
         if display_name:
-            entity = kplib.ConcreteEntity(
+            entity = ConcreteEntity(
                 name=display_name,
                 type=["person"],
             )
             if address:
                 entity.facets = [
-                    kplib.Facet(
+                    Facet(
                         name="email_address",
                         value=address,
                     )
@@ -96,18 +94,16 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
 
         if address:
             entities.append(
-                kplib.ConcreteEntity(
+                ConcreteEntity(
                     name=address,
                     type=["email_address", "alias"],
                 )
             )
         return entities
 
-    def _create_actions(
-        self, verb: str, sender: str, recipient: str
-    ) -> list[kplib.Action]:
+    def _create_actions(self, verb: str, sender: str, recipient: str) -> list[Action]:
         sender_display_name, sender_address = parseaddr(sender)
-        actions: list[kplib.Action] = []
+        actions: list[Action] = []
         if sender_display_name:
             self._add_actions_for_sender(actions, verb, sender_display_name, recipient)
 
@@ -117,7 +113,7 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
         return actions
 
     def _add_actions_for_sender(
-        self, actions: list[kplib.Action], verb: str, sender: str, recipient: str
+        self, actions: list[Action], verb: str, sender: str, recipient: str
     ) -> None:
         recipient_display_name, recipient_address = parseaddr(recipient)
         if recipient_display_name:
@@ -128,9 +124,9 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
 
     def _create_action(
         self, verb: str, sender: str, recipient: str, use_indirect: bool = True
-    ) -> kplib.Action:
+    ) -> Action:
         if use_indirect:
-            return kplib.Action(
+            return Action(
                 verbs=[verb],
                 verb_tense="past",
                 subject_entity_name=sender,
@@ -138,7 +134,7 @@ class EmailMessageMeta(IKnowledgeSource, IMessageMetadata):
                 indirect_object_entity_name=recipient,
             )
         else:
-            return kplib.Action(
+            return Action(
                 verbs=[verb],
                 verb_tense="past",
                 subject_entity_name=sender,
@@ -163,7 +159,7 @@ class EmailMessage(IMessage):
     src_url: str | None = None  # Source file or uri for this email
     source_id: str | None = None  # External source id (see IMessage.source_id)
 
-    def get_knowledge(self) -> kplib.KnowledgeResponse:
+    def get_knowledge(self) -> KnowledgeResponse:
         return self.metadata.get_knowledge()
 
     def add_timestamp(self, timestamp: str) -> None:

--- a/src/typeagent/knowpro/add_messages.py
+++ b/src/typeagent/knowpro/add_messages.py
@@ -11,11 +11,11 @@ from typing import TYPE_CHECKING
 
 import typechat
 
-from . import knowledge_schema as kplib
 from ..aitools.embeddings import IEmbeddingModel, NormalizedEmbedding
 from ..storage.memory.semrefindex import collect_action_terms, collect_entity_terms
 from .interfaces import AddMessagesResult
 from .interfaces_core import IKnowledgeExtractor, IMessage, MessageOrdinal, TextLocation
+from .knowledge_schema import KnowledgeResponse
 
 __all__ = ["add_messages_streaming"]
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 type ChunkOrdinal = int
 
-_EMPTY_KNOWLEDGE = kplib.KnowledgeResponse(
+_EMPTY_KNOWLEDGE = KnowledgeResponse(
     entities=[], actions=[], inverse_actions=[], topics=[]
 )
 
@@ -32,7 +32,7 @@ _EMPTY_KNOWLEDGE = kplib.KnowledgeResponse(
 class NoOpKnowledgeExtractor:
     """No-op extractor used when auto_extract_knowledge is False."""
 
-    async def extract(self, message: str) -> typechat.Result[kplib.KnowledgeResponse]:
+    async def extract(self, message: str) -> typechat.Result[KnowledgeResponse]:
         return typechat.Success(_EMPTY_KNOWLEDGE)
 
 
@@ -226,7 +226,7 @@ class ChunkProcessingResult[TMessage: IMessage]:
     chunk_id: TextLocation
     chunk_count: int
     message: TMessage
-    extracted_knowledge: kplib.KnowledgeResponse | None = None
+    extracted_knowledge: KnowledgeResponse | None = None
     chunk_embedding: NormalizedEmbedding | None = None
     related_terms: list[str] | None = None
     related_term_embeddings: list[NormalizedEmbedding] | None = None
@@ -234,7 +234,7 @@ class ChunkProcessingResult[TMessage: IMessage]:
 
 
 def _collect_related_terms_for_fuzzy_index(
-    knowledge: kplib.KnowledgeResponse,
+    knowledge: KnowledgeResponse,
 ) -> list[str]:
     """Collect canonical related-term texts for the fuzzy related-terms index.
 

--- a/src/typeagent/knowpro/conversation_base.py
+++ b/src/typeagent/knowpro/conversation_base.py
@@ -15,13 +15,10 @@ from . import (
     answer_response_schema,
     answers,
     convknowledge,
-)
-from . import (
     search_query_schema,
     searchlang,
     secindex,
 )
-from . import knowledge_schema as kplib
 from ..aitools import model_adapters, utils
 from ..aitools.embeddings import NormalizedEmbedding
 from ..storage.memory import semrefindex
@@ -40,6 +37,7 @@ from .interfaces import (
     Topic,
 )
 from .interfaces_core import TextLocation
+from .knowledge_schema import Action, ConcreteEntity, KnowledgeResponse
 from .messageutils import get_all_message_chunk_locations
 
 TMessage = TypeVar("TMessage", bound=IMessage)
@@ -50,7 +48,7 @@ class _ChunkCommitResult(Protocol):
 
     chunk_id: TextLocation
     chunk_count: int
-    extracted_knowledge: kplib.KnowledgeResponse | None
+    extracted_knowledge: KnowledgeResponse | None
     chunk_embedding: NormalizedEmbedding | None
     related_terms: list[str] | None
     related_term_embeddings: list[NormalizedEmbedding] | None
@@ -244,7 +242,7 @@ class ConversationBase(
             return AddMessagesResult()
 
         # Process chunk results first to collect embeddings and knowledge items
-        knowledge_items: list[tuple[MessageOrdinal, int, kplib.KnowledgeResponse]] = []
+        knowledge_items: list[tuple[MessageOrdinal, int, KnowledgeResponse]] = []
         fuzzy_terms: list[str] = []
         fuzzy_term_embeddings: list[NormalizedEmbedding] = []
         chunk_embedding_map: dict[tuple[int, int], NormalizedEmbedding] = {}
@@ -495,11 +493,11 @@ class ConversationBase(
             new_terms = set()
             for semref in new_semrefs:
                 knowledge = semref.knowledge
-                if isinstance(knowledge, kplib.ConcreteEntity):
+                if isinstance(knowledge, ConcreteEntity):
                     new_terms.add(knowledge.name.lower())
                 elif isinstance(knowledge, Topic):
                     new_terms.add(knowledge.text.lower())
-                elif isinstance(knowledge, kplib.Action):
+                elif isinstance(knowledge, Action):
                     for verb in knowledge.verbs:
                         new_terms.add(verb.lower())
 

--- a/src/typeagent/knowpro/convknowledge.py
+++ b/src/typeagent/knowpro/convknowledge.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass, field
 
 import typechat
 
-from . import knowledge_schema as kplib
 from ..aitools.model_adapters import create_chat_model
+from .knowledge_schema import KnowledgeResponse
 
 
 @dataclass
@@ -17,16 +17,14 @@ class KnowledgeExtractor:
         False  # TODO: Implement merge_action_knowledge_into_response
     )
     # Not in the signature:
-    translator: typechat.TypeChatJsonTranslator[kplib.KnowledgeResponse] = field(
-        init=False
-    )
+    translator: typechat.TypeChatJsonTranslator[KnowledgeResponse] = field(init=False)
 
     def __post_init__(self):
         self.translator = self.create_translator(self.model)
 
     # TODO: Use max_chars_per_chunk and merge_action_knowledge.
 
-    async def extract(self, message: str) -> typechat.Result[kplib.KnowledgeResponse]:
+    async def extract(self, message: str) -> typechat.Result[KnowledgeResponse]:
         result = await self.translator.translate(message)
         if isinstance(result, typechat.Success):
             if self.merge_action_knowledge:
@@ -37,12 +35,12 @@ class KnowledgeExtractor:
 
     def create_translator(
         self, model: typechat.TypeChatLanguageModel
-    ) -> typechat.TypeChatJsonTranslator[kplib.KnowledgeResponse]:
-        schema = kplib.KnowledgeResponse
+    ) -> typechat.TypeChatJsonTranslator[KnowledgeResponse]:
+        schema = KnowledgeResponse
         type_name = "KnowledgeResponse"
-        validator = typechat.TypeChatValidator[kplib.KnowledgeResponse](schema)
-        translator = typechat.TypeChatJsonTranslator[kplib.KnowledgeResponse](
-            model, validator, kplib.KnowledgeResponse
+        validator = typechat.TypeChatValidator[KnowledgeResponse](schema)
+        translator = typechat.TypeChatJsonTranslator[KnowledgeResponse](
+            model, validator, KnowledgeResponse
         )
         schema_text = translator.schema_str.rstrip()
 
@@ -66,7 +64,7 @@ class KnowledgeExtractor:
         return translator
 
     def merge_action_knowledge_into_response(
-        self, knowledge: kplib.KnowledgeResponse
+        self, knowledge: KnowledgeResponse
     ) -> None:
         """Merge action knowledge into a single knowledge object."""
         raise NotImplementedError("TODO")

--- a/src/typeagent/knowpro/interfaces_core.py
+++ b/src/typeagent/knowpro/interfaces_core.py
@@ -20,8 +20,8 @@ from typing import (
 from pydantic.dataclasses import dataclass
 import typechat
 
-from . import knowledge_schema as kplib
 from .field_helpers import CamelCaseField
+from .knowledge_schema import Action, ConcreteEntity, KnowledgeResponse
 
 __all__ = [
     "AddMessagesResult",
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 class IKnowledgeSource(Protocol):
     """A Knowledge Source is any object that returns knowledge."""
 
-    def get_knowledge(self) -> kplib.KnowledgeResponse:
+    def get_knowledge(self) -> KnowledgeResponse:
         """Retrieves knowledge from the source."""
         ...
 
@@ -67,7 +67,7 @@ class IKnowledgeSource(Protocol):
 class IKnowledgeExtractor(Protocol):
     """Interface for extracting knowledge from messages."""
 
-    async def extract(self, message: str) -> typechat.Result[kplib.KnowledgeResponse]:
+    async def extract(self, message: str) -> typechat.Result[KnowledgeResponse]:
         """Extract knowledge from a message."""
         ...
 
@@ -212,7 +212,7 @@ class Tag:
     text: str
 
 
-type Knowledge = kplib.ConcreteEntity | kplib.Action | Topic | Tag
+type Knowledge = ConcreteEntity | Action | Topic | Tag
 
 
 class TextLocationData(TypedDict):
@@ -306,7 +306,7 @@ class TextRange:
         return TextRange.__pydantic_validator__.validate_python(data)  # type: ignore
 
 
-# TODO: Implement serializing KnowledgeData (or import from kplib).
+# TODO: Implement serializing KnowledgeData (or import from knowledge_schema).
 class KnowledgeData(TypedDict):
     pass
 

--- a/src/typeagent/knowpro/knowledge.py
+++ b/src/typeagent/knowpro/knowledge.py
@@ -7,14 +7,14 @@ from dataclasses import dataclass
 
 from typechat import Result
 
-from . import knowledge_schema as kplib
 from .interfaces import IKnowledgeExtractor
+from .knowledge_schema import ConcreteEntity, Facet, KnowledgeResponse
 
 
 async def extract_knowledge_from_text(
     knowledge_extractor: IKnowledgeExtractor,
     text: str,
-) -> Result[kplib.KnowledgeResponse]:
+) -> Result[KnowledgeResponse]:
     """Extract knowledge from a single text input."""
     return await knowledge_extractor.extract(text)
 
@@ -22,7 +22,7 @@ async def extract_knowledge_from_text(
 async def batch_worker(
     q: asyncio.Queue[tuple[int, str] | None],
     knowledge_extractor: IKnowledgeExtractor,
-    results: dict[int, Result[kplib.KnowledgeResponse]],
+    results: dict[int, Result[KnowledgeResponse]],
 ) -> None:
     while item := await q.get():
         index, text = item
@@ -34,7 +34,7 @@ async def extract_knowledge_from_text_batch(
     knowledge_extractor: IKnowledgeExtractor,
     text_batch: list[str],
     concurrency: int = 4,
-) -> list[Result[kplib.KnowledgeResponse]]:
+) -> list[Result[KnowledgeResponse]]:
     """Extract knowledge from a batch of text inputs concurrently."""
     if not text_batch:
         return []
@@ -42,7 +42,7 @@ async def extract_knowledge_from_text_batch(
     q: asyncio.Queue[tuple[int, str] | None] = asyncio.Queue(
         maxsize=2 * concurrency + 2
     )
-    results: dict[int, Result[kplib.KnowledgeResponse]] = {}
+    results: dict[int, Result[KnowledgeResponse]] = {}
 
     async with asyncio.TaskGroup() as tg:
         for _ in range(concurrency):
@@ -66,9 +66,9 @@ class _MergedEntity:
 
 
 def merge_concrete_entities(
-    entities: list[kplib.ConcreteEntity],
+    entities: list[ConcreteEntity],
     normalize: Callable[[str], str] = str.lower,
-) -> list[kplib.ConcreteEntity]:
+) -> list[ConcreteEntity]:
     """Merge a list of concrete entities by name, combining types and facets.
 
     Entities with the same name (after normalization) are merged:
@@ -119,7 +119,7 @@ def merge_concrete_entities(
     # Convert merged entities back to ConcreteEntity, sorted by name
     result = []
     for merged_entity in sorted(merged.values(), key=lambda e: e.name):
-        concrete = kplib.ConcreteEntity(
+        concrete = ConcreteEntity(
             name=merged_entity.name,
             type=sorted(merged_entity.types),
         )
@@ -132,7 +132,7 @@ def merge_concrete_entities(
 
 def _add_facet_to_merged(
     merged: dict[str, set[str]],
-    facet: kplib.Facet,
+    facet: Facet,
     normalize: Callable[[str], str],
 ) -> None:
     """Add a single facet to a merged facets dict."""
@@ -142,7 +142,7 @@ def _add_facet_to_merged(
 
 
 def _facets_to_merged(
-    facets: list[kplib.Facet],
+    facets: list[Facet],
     normalize: Callable[[str], str],
 ) -> dict[str, set[str]]:
     """Convert a list of Facets to a merged facets dict.
@@ -157,7 +157,7 @@ def _facets_to_merged(
 
 def _merge_facets(
     existing: dict[str, set[str]],
-    facets: list[kplib.Facet],
+    facets: list[Facet],
     normalize: Callable[[str], str],
 ) -> None:
     """Merge facets into an existing facets dict."""
@@ -165,12 +165,12 @@ def _merge_facets(
         _add_facet_to_merged(existing, facet, normalize)
 
 
-def _merged_to_facets(merged_facets: dict[str, set[str]]) -> list[kplib.Facet]:
+def _merged_to_facets(merged_facets: dict[str, set[str]]) -> list[Facet]:
     """Convert a merged facets dict back to a list of Facets."""
     facets = []
     for name, values in sorted(merged_facets.items()):
         if values:
-            facets.append(kplib.Facet(name=name, value="; ".join(sorted(values))))
+            facets.append(Facet(name=name, value="; ".join(sorted(values))))
     return facets
 
 

--- a/src/typeagent/knowpro/serialization.py
+++ b/src/typeagent/knowpro/serialization.py
@@ -24,9 +24,9 @@ import numpy as np
 
 from pydantic.alias_generators import to_camel
 
-from . import knowledge_schema as kplib
 from ..aitools.embeddings import NormalizedEmbeddings
 from .interfaces import ConversationDataWithIndexes, SearchTermGroupTypes, Tag, Topic
+from .knowledge_schema import Action, ConcreteEntity
 
 # -------------------
 # Shared definitions
@@ -251,8 +251,8 @@ def get_embeddings_from_binary_data(
 
 
 TYPE_MAP = {
-    "entity": kplib.ConcreteEntity,
-    "action": kplib.Action,
+    "entity": ConcreteEntity,
+    "action": Action,
     "topic": Topic,
     "tag": Tag,
 }

--- a/src/typeagent/knowpro/universal_message.py
+++ b/src/typeagent/knowpro/universal_message.py
@@ -8,10 +8,10 @@ from typing import TypedDict
 
 from pydantic import AliasChoices, Field
 
-from . import knowledge_schema as kplib
 from .dataclasses import dataclass as pydantic_dataclass
 from .field_helpers import CamelCaseField
 from .interfaces import IKnowledgeSource, IMessage, IMessageMetadata
+from .knowledge_schema import Action, ConcreteEntity, KnowledgeResponse
 
 # Unix epoch sentinel for unknown dates (Easter egg!)
 UNIX_EPOCH = datetime(1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
@@ -94,7 +94,7 @@ class ConversationMessageMeta(IKnowledgeSource, IMessageMetadata):
         """IMessageMetadata.dest property - returns recipients if any."""
         return self.recipients if self.recipients else None
 
-    def get_knowledge(self) -> kplib.KnowledgeResponse:
+    def get_knowledge(self) -> KnowledgeResponse:
         """
         Extract structured knowledge from metadata.
 
@@ -103,7 +103,7 @@ class ConversationMessageMeta(IKnowledgeSource, IMessageMetadata):
         - "Say/speak" actions linking speaker to each recipient
         """
         if not self.speaker:
-            return kplib.KnowledgeResponse(
+            return KnowledgeResponse(
                 entities=[],
                 actions=[],
                 inverse_actions=[],
@@ -111,8 +111,8 @@ class ConversationMessageMeta(IKnowledgeSource, IMessageMetadata):
             )
 
         # Create speaker entity
-        entities: list[kplib.ConcreteEntity] = [
-            kplib.ConcreteEntity(
+        entities: list[ConcreteEntity] = [
+            ConcreteEntity(
                 name=self.speaker,
                 type=["person"],
             )
@@ -121,7 +121,7 @@ class ConversationMessageMeta(IKnowledgeSource, IMessageMetadata):
         # Create recipient entities
         entities.extend(
             [
-                kplib.ConcreteEntity(
+                ConcreteEntity(
                     name=recipient,
                     type=["person"],
                 )
@@ -133,7 +133,7 @@ class ConversationMessageMeta(IKnowledgeSource, IMessageMetadata):
         if self.recipients:
             # Podcast style: speaker says to each recipient
             actions = [
-                kplib.Action(
+                Action(
                     verbs=["say"],
                     verb_tense="past",
                     subject_entity_name=self.speaker,
@@ -145,7 +145,7 @@ class ConversationMessageMeta(IKnowledgeSource, IMessageMetadata):
         else:
             # Transcript style: speaker speaks (no specific audience)
             actions = [
-                kplib.Action(
+                Action(
                     verbs=["say", "speak"],
                     verb_tense="past",
                     subject_entity_name=self.speaker,
@@ -154,7 +154,7 @@ class ConversationMessageMeta(IKnowledgeSource, IMessageMetadata):
                 )
             ]
 
-        return kplib.KnowledgeResponse(
+        return KnowledgeResponse(
             entities=entities,
             actions=actions,
             inverse_actions=[],
@@ -210,7 +210,7 @@ class ConversationMessage(IMessage):
     (e.g., a transcript file path or podcast episode id). See ``IMessage.source_id``.
     """
 
-    def get_knowledge(self) -> kplib.KnowledgeResponse:
+    def get_knowledge(self) -> KnowledgeResponse:
         return self.metadata.get_knowledge()
 
     def add_timestamp(self, timestamp: str) -> None:

--- a/src/typeagent/storage/memory/propindex.py
+++ b/src/typeagent/storage/memory/propindex.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 import enum
 from typing import assert_never
 
-from ...knowpro import knowledge_schema as kplib
 from ...knowpro.collections import TextRangesInScope
 from ...knowpro.interfaces import (
     IConversation,
@@ -16,6 +15,7 @@ from ...knowpro.interfaces import (
     Tag,
     Topic,
 )
+from ...knowpro.knowledge_schema import Action, ConcreteEntity, Facet
 
 
 class PropertyNames(enum.Enum):
@@ -32,7 +32,7 @@ class PropertyNames(enum.Enum):
 
 
 async def add_facet(
-    facet: kplib.Facet | None,
+    facet: Facet | None,
     property_index: IPropertyToSemanticRefIndex,
     semantic_ref_ordinal: SemanticRefOrdinal,
 ) -> None:
@@ -55,7 +55,7 @@ async def add_facet(
 
 
 async def add_entity_properties_to_index(
-    entity: kplib.ConcreteEntity,
+    entity: ConcreteEntity,
     property_index: IPropertyToSemanticRefIndex,
     semantic_ref_ordinal: SemanticRefOrdinal,
 ) -> None:
@@ -77,7 +77,7 @@ async def add_entity_properties_to_index(
 
 
 async def add_action_properties_to_index(
-    action: kplib.Action,
+    action: Action,
     property_index: IPropertyToSemanticRefIndex,
     semantic_ref_ordinal: SemanticRefOrdinal,
 ) -> None:
@@ -111,7 +111,7 @@ async def build_property_index(conversation: IConversation) -> None:
 
 
 def collect_facet_properties(
-    facet: kplib.Facet | None,
+    facet: Facet | None,
     ordinal: SemanticRefOrdinal,
 ) -> list[tuple[str, str, SemanticRefOrdinal]]:
     """Collect property tuples from a facet without touching any index."""
@@ -129,7 +129,7 @@ def collect_facet_properties(
 
 
 def collect_entity_properties(
-    entity: kplib.ConcreteEntity,
+    entity: ConcreteEntity,
     ordinal: SemanticRefOrdinal,
 ) -> list[tuple[str, str, SemanticRefOrdinal]]:
     """Collect all property tuples for an entity."""
@@ -145,7 +145,7 @@ def collect_entity_properties(
 
 
 def collect_action_properties(
-    action: kplib.Action,
+    action: Action,
     ordinal: SemanticRefOrdinal,
 ) -> list[tuple[str, str, SemanticRefOrdinal]]:
     """Collect all property tuples for an action."""
@@ -191,13 +191,13 @@ async def add_to_property_index(
             start_at_ordinal,
         ):
             assert semantic_ref.semantic_ref_ordinal == semantic_ref_ordinal
-            if isinstance(semantic_ref.knowledge, kplib.Action):
+            if isinstance(semantic_ref.knowledge, Action):
                 collected.extend(
                     collect_action_properties(
                         semantic_ref.knowledge, semantic_ref_ordinal
                     )
                 )
-            elif isinstance(semantic_ref.knowledge, kplib.ConcreteEntity):
+            elif isinstance(semantic_ref.knowledge, ConcreteEntity):
                 collected.extend(
                     collect_entity_properties(
                         semantic_ref.knowledge, semantic_ref_ordinal

--- a/src/typeagent/storage/memory/semrefindex.py
+++ b/src/typeagent/storage/memory/semrefindex.py
@@ -7,9 +7,7 @@ from collections.abc import AsyncIterable, Callable, Sequence
 
 from typechat import Failure
 
-from ...knowpro import convknowledge
-from ...knowpro import knowledge_schema as kplib
-from ...knowpro import secindex
+from ...knowpro import convknowledge, secindex
 from ...knowpro.convsettings import ConversationSettings, SemanticRefIndexSettings
 from ...knowpro.interfaces import (  # Interfaces.; Other imports.
     IConversation,
@@ -29,6 +27,7 @@ from ...knowpro.interfaces import (  # Interfaces.; Other imports.
     Topic,
 )
 from ...knowpro.knowledge import extract_knowledge_from_text_batch
+from ...knowpro.knowledge_schema import Action, ConcreteEntity, Facet, KnowledgeResponse
 from ...knowpro.messageutils import (
     text_range_from_message_chunk,
 )
@@ -65,7 +64,7 @@ async def add_batch_to_semantic_ref_index[
         text_batch,
         concurrency,
     )
-    bulk_items: list[tuple[int, int, kplib.KnowledgeResponse]] = []
+    bulk_items: list[tuple[int, int, KnowledgeResponse]] = []
     for i, knowledge_result in enumerate(knowledge_results):
         if isinstance(knowledge_result, Failure):
             raise RuntimeError(
@@ -108,7 +107,7 @@ async def add_batch_to_semantic_ref_index_from_list[
         text_batch,
         concurrency,
     )
-    bulk_items: list[tuple[int, int, kplib.KnowledgeResponse]] = []
+    bulk_items: list[tuple[int, int, KnowledgeResponse]] = []
     for i, knowledge_result in enumerate(knowledge_results):
         if isinstance(knowledge_result, Failure):
             raise RuntimeError(
@@ -142,7 +141,7 @@ async def add_term_to_index(
 
 
 async def add_entity(
-    entity: kplib.ConcreteEntity,
+    entity: ConcreteEntity,
     semantic_refs: ISemanticRefCollection,
     semantic_ref_index: ITermToSemanticRefIndex,
     message_ordinal: MessageOrdinal,
@@ -187,7 +186,7 @@ async def add_entity(
 
 
 async def add_facet(
-    facet: kplib.Facet | None,
+    facet: Facet | None,
     semantic_ref_ordinal: SemanticRefOrdinal,
     semantic_ref_index: ITermToSemanticRefIndex,
     terms_added: set[str] | None = None,
@@ -246,7 +245,7 @@ async def add_topic(
 
 
 async def add_action(
-    action: kplib.Action,
+    action: Action,
     semantic_refs: ISemanticRefCollection,
     semantic_ref_index: ITermToSemanticRefIndex,
     message_ordinal: MessageOrdinal,
@@ -343,7 +342,7 @@ def _collect_knowledge_refs_and_terms(
     base_ordinal: SemanticRefOrdinal,
     message_ordinal: MessageOrdinal,
     chunk_ordinal: int,
-    knowledge: kplib.KnowledgeResponse,
+    knowledge: KnowledgeResponse,
 ) -> tuple[list[SemanticRef], list[tuple[str, SemanticRefOrdinal]]]:
     """Collect SemanticRefs and index terms without writing to storage."""
     refs: list[SemanticRef] = []
@@ -419,7 +418,7 @@ async def add_knowledge_to_semantic_ref_index(
     conversation: IConversation,
     message_ordinal: MessageOrdinal,
     chunk_ordinal: int,
-    knowledge: kplib.KnowledgeResponse,
+    knowledge: KnowledgeResponse,
 ) -> None:
     """Add knowledge to the semantic reference index of a conversation."""
     verify_has_semantic_ref_index(conversation)
@@ -445,7 +444,7 @@ async def add_knowledge_to_semantic_ref_index(
 
 async def add_knowledge_batch_to_semantic_ref_index(
     conversation: IConversation,
-    items: list[tuple[MessageOrdinal, int, kplib.KnowledgeResponse]],
+    items: list[tuple[MessageOrdinal, int, KnowledgeResponse]],
 ) -> None:
     """Bulk-add knowledge from multiple chunks in two DB round-trips."""
     if not items:
@@ -477,7 +476,7 @@ async def add_knowledge_batch_to_semantic_ref_index(
         await semantic_ref_index.add_terms_batch(all_terms)
 
 
-def validate_entity(entity: kplib.ConcreteEntity) -> bool:
+def validate_entity(entity: ConcreteEntity) -> bool:
     return bool(entity.name)
 
 
@@ -485,7 +484,7 @@ async def add_knowledge_to_index(
     semantic_refs: ISemanticRefCollection,
     semantic_ref_index: ITermToSemanticRefIndex,
     message_ordinal: MessageOrdinal,
-    knowledge: kplib.KnowledgeResponse,
+    knowledge: KnowledgeResponse,
 ) -> None:
     for entity in knowledge.entities:
         await add_entity(entity, semantic_refs, semantic_ref_index, message_ordinal)
@@ -543,7 +542,7 @@ async def add_metadata_to_index[TMessage: IMessage](
         i += 1
 
 
-def collect_facet_terms(facet: kplib.Facet | None) -> list[str]:
+def collect_facet_terms(facet: Facet | None) -> list[str]:
     """Collect terms from a facet without touching any index."""
     if facet is None:
         return []
@@ -553,7 +552,7 @@ def collect_facet_terms(facet: kplib.Facet | None) -> list[str]:
     return terms
 
 
-def collect_entity_terms(entity: kplib.ConcreteEntity) -> list[str]:
+def collect_entity_terms(entity: ConcreteEntity) -> list[str]:
     """Collect all terms an entity would add to the semantic ref index."""
     terms = [entity.name]
     for t in entity.type:
@@ -564,7 +563,7 @@ def collect_entity_terms(entity: kplib.ConcreteEntity) -> list[str]:
     return terms
 
 
-def collect_action_terms(action: kplib.Action) -> list[str]:
+def collect_action_terms(action: Action) -> list[str]:
     """Collect all terms an action would add to the semantic ref index."""
     terms = [" ".join(action.verbs)]
     if action.subject_entity_name != "none":

--- a/tests/test_add_messages_pipeline.py
+++ b/tests/test_add_messages_pipeline.py
@@ -13,7 +13,6 @@ import pytest
 import typechat
 
 from typeagent.aitools.embeddings import NormalizedEmbedding, NormalizedEmbeddings
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.add_messages import (
     _collect_related_terms_for_fuzzy_index,
     _dispatcher_task,
@@ -30,6 +29,12 @@ from typeagent.knowpro.interfaces_core import (
     IMessageMetadata,
     TextLocation,
 )
+from typeagent.knowpro.knowledge_schema import (
+    Action,
+    ConcreteEntity,
+    Facet,
+    KnowledgeResponse,
+)
 
 
 @dataclass
@@ -41,18 +46,18 @@ class _Message:
     metadata: IMessageMetadata | None = None
     source_id: str | None = None
 
-    def get_knowledge(self) -> kplib.KnowledgeResponse:
+    def get_knowledge(self) -> KnowledgeResponse:
         return _empty_knowledge()
 
 
 class _SequenceExtractor:
     def __init__(
-        self, outputs: list[typechat.Result[kplib.KnowledgeResponse] | Exception]
+        self, outputs: list[typechat.Result[KnowledgeResponse] | Exception]
     ) -> None:
         self._outputs = outputs
         self.calls: list[str] = []
 
-    async def extract(self, message: str) -> typechat.Result[kplib.KnowledgeResponse]:
+    async def extract(self, message: str) -> typechat.Result[KnowledgeResponse]:
         self.calls.append(message)
         output = self._outputs[len(self.calls) - 1]
         if isinstance(output, Exception):
@@ -150,25 +155,23 @@ def _embedding(values: list[float]) -> NormalizedEmbedding:
     return np.array(values, dtype=np.float32)
 
 
-def _empty_knowledge() -> kplib.KnowledgeResponse:
-    return kplib.KnowledgeResponse(
-        entities=[], actions=[], inverse_actions=[], topics=[]
-    )
+def _empty_knowledge() -> KnowledgeResponse:
+    return KnowledgeResponse(entities=[], actions=[], inverse_actions=[], topics=[])
 
 
-def _knowledge_with_terms() -> kplib.KnowledgeResponse:
-    entity = kplib.ConcreteEntity(
+def _knowledge_with_terms() -> KnowledgeResponse:
+    entity = ConcreteEntity(
         name=" Alice ",
         type=["Person"],
-        facets=[kplib.Facet(name="Role", value="Engineer")],
+        facets=[Facet(name="Role", value="Engineer")],
     )
-    action = kplib.Action(
+    action = Action(
         verbs=["Mentors"],
         verb_tense="present",
         subject_entity_name="Alice",
         object_entity_name="Bob",
     )
-    return kplib.KnowledgeResponse(
+    return KnowledgeResponse(
         entities=[entity],
         actions=[action],
         inverse_actions=[],

--- a/tests/test_add_messages_streaming.py
+++ b/tests/test_add_messages_streaming.py
@@ -12,10 +12,10 @@ import pytest
 import typechat
 
 from typeagent.aitools.model_adapters import create_test_embedding_model
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.add_messages import add_messages_streaming
 from typeagent.knowpro.convsettings import ConversationSettings
 from typeagent.knowpro.interfaces_core import IKnowledgeExtractor
+from typeagent.knowpro.knowledge_schema import KnowledgeResponse
 from typeagent.storage.sqlite.provider import SqliteStorageProvider
 from typeagent.transcripts.transcript import (
     Transcript,
@@ -86,7 +86,7 @@ def _failure_count(storage: SqliteStorageProvider) -> int:
 # A test IKnowledgeExtractor that lets us control per-call results
 # ---------------------------------------------------------------------------
 
-_EMPTY_RESPONSE = kplib.KnowledgeResponse(
+_EMPTY_RESPONSE = KnowledgeResponse(
     entities=[], actions=[], inverse_actions=[], topics=[]
 )
 
@@ -109,7 +109,7 @@ class ControlledExtractor:
         self.raise_on = raise_on or set()
         self.call_count = 0
 
-    async def extract(self, message: str) -> typechat.Result[kplib.KnowledgeResponse]:
+    async def extract(self, message: str) -> typechat.Result[KnowledgeResponse]:
         idx = self.call_count
         self.call_count += 1
         if idx in self.raise_on:

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -6,22 +6,21 @@ import pytest
 from typechat import Failure, Result, Success
 
 from typeagent.knowpro import convknowledge
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.knowledge import (
     extract_knowledge_from_text,
     extract_knowledge_from_text_batch,
     merge_concrete_entities,
     merge_topics,
 )
-from typeagent.knowpro.knowledge_schema import ConcreteEntity, Facet
+from typeagent.knowpro.knowledge_schema import ConcreteEntity, Facet, KnowledgeResponse
 
 
 class MockKnowledgeExtractor:
-    async def extract(self, text: str) -> Result[kplib.KnowledgeResponse]:
+    async def extract(self, text: str) -> Result[KnowledgeResponse]:
         if text == "error":
             return Failure("Extraction failed")
         return Success(
-            kplib.KnowledgeResponse(
+            KnowledgeResponse(
                 entities=[], actions=[], inverse_actions=[], topics=[text]
             )
         )

--- a/tests/test_memory_semrefindex.py
+++ b/tests/test_memory_semrefindex.py
@@ -5,8 +5,8 @@
 
 import pytest
 
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.interfaces import Topic
+from typeagent.knowpro.knowledge_schema import Action, ConcreteEntity, Facet
 from typeagent.storage.memory import MemorySemanticRefCollection
 from typeagent.storage.memory.semrefindex import (
     add_action,
@@ -72,7 +72,7 @@ async def test_add_facet_none_does_nothing() -> None:
 @pytest.mark.asyncio
 async def test_add_facet_string_value() -> None:
     index = make_index()
-    facet = kplib.Facet(name="colour", value="red")
+    facet = Facet(name="colour", value="red")
     await add_facet(facet, 0, index)
     terms = await index.get_terms()
     assert "colour" in terms
@@ -82,7 +82,7 @@ async def test_add_facet_string_value() -> None:
 @pytest.mark.asyncio
 async def test_add_facet_numeric_value() -> None:
     index = make_index()
-    facet = kplib.Facet(name="count", value=42.0)
+    facet = Facet(name="count", value=42.0)
     await add_facet(facet, 0, index)
     terms = await index.get_terms()
     assert "count" in terms
@@ -98,7 +98,7 @@ async def test_add_facet_numeric_value() -> None:
 async def test_add_entity_registers_name_and_types() -> None:
     semrefs = make_semrefs()
     index = make_index()
-    entity = kplib.ConcreteEntity(name="Alice", type=["person", "employee"])
+    entity = ConcreteEntity(name="Alice", type=["person", "employee"])
     terms_added: set[str] = set()
     await add_entity(
         entity,
@@ -118,10 +118,10 @@ async def test_add_entity_registers_name_and_types() -> None:
 async def test_add_entity_with_facets() -> None:
     semrefs = make_semrefs()
     index = make_index()
-    entity = kplib.ConcreteEntity(
+    entity = ConcreteEntity(
         name="Book",
         type=["item"],
-        facets=[kplib.Facet(name="genre", value="fiction")],
+        facets=[Facet(name="genre", value="fiction")],
     )
     await add_entity(entity, semrefs, index, message_ordinal=1, chunk_ordinal=0)
     terms = await index.get_terms()
@@ -161,7 +161,7 @@ async def test_add_topic_registers_text() -> None:
 async def test_add_action_registers_verbs() -> None:
     semrefs = make_semrefs()
     index = make_index()
-    action = kplib.Action(
+    action = Action(
         verbs=["run", "execute"],
         verb_tense="present",
         subject_entity_name="Alice",
@@ -188,7 +188,7 @@ async def test_add_action_registers_verbs() -> None:
 async def test_add_action_none_entities_skipped() -> None:
     semrefs = make_semrefs()
     index = make_index()
-    action = kplib.Action(
+    action = Action(
         verbs=["go"],
         verb_tense="present",
         subject_entity_name="none",

--- a/tests/test_podcasts.py
+++ b/tests/test_podcasts.py
@@ -10,9 +10,9 @@ import pytest
 from typechat import Result, Success
 
 from typeagent.aitools.embeddings import IEmbeddingModel
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.convsettings import ConversationSettings
 from typeagent.knowpro.interfaces import Datetime
+from typeagent.knowpro.knowledge_schema import KnowledgeResponse
 from typeagent.knowpro.serialization import DATA_FILE_SUFFIX, EMBEDDING_FILE_SUFFIX
 from typeagent.podcasts import podcast_ingest
 from typeagent.podcasts.podcast import Podcast
@@ -27,14 +27,14 @@ class TrackingKnowledgeExtractor:
         self.max_concurrency = 0
         self.started_texts: list[str] = []
 
-    async def extract(self, message: str) -> Result[kplib.KnowledgeResponse]:
+    async def extract(self, message: str) -> Result[KnowledgeResponse]:
         self.started_texts.append(message)
         self.current_concurrency += 1
         self.max_concurrency = max(self.max_concurrency, self.current_concurrency)
         try:
             await asyncio.sleep(self.delay)
             return Success(
-                kplib.KnowledgeResponse(
+                KnowledgeResponse(
                     entities=[],
                     actions=[],
                     inverse_actions=[],

--- a/tests/test_property_index_population.py
+++ b/tests/test_property_index_population.py
@@ -12,12 +12,12 @@ import pytest
 
 from typeagent.aitools.model_adapters import create_test_embedding_model
 from typeagent.aitools.vectorbase import TextEmbeddingIndexSettings
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.convsettings import (
     MessageTextIndexSettings,
     RelatedTermIndexSettings,
 )
 from typeagent.knowpro.interfaces import SemanticRef, Tag, TextLocation, TextRange
+from typeagent.knowpro.knowledge_schema import Action, ConcreteEntity, Facet
 from typeagent.podcasts.podcast import PodcastMessage
 from typeagent.storage import SqliteStorageProvider
 
@@ -53,17 +53,17 @@ async def test_property_index_population_from_database(really_needs_auth):
             SemanticRef(
                 semantic_ref_ordinal=0,
                 range=text_range,
-                knowledge=kplib.ConcreteEntity(
+                knowledge=ConcreteEntity(
                     name="John Doe",
                     type=["person", "speaker"],
-                    facets=[kplib.Facet(name="role", value="host")],
+                    facets=[Facet(name="role", value="host")],
                 ),
             ),
             # Action
             SemanticRef(
                 semantic_ref_ordinal=1,
                 range=text_range,
-                knowledge=kplib.Action(
+                knowledge=Action(
                     verbs=["discuss", "explain"],
                     verb_tense="present",
                     subject_entity_name="John Doe",

--- a/tests/test_related_terms_index_population.py
+++ b/tests/test_related_terms_index_population.py
@@ -12,12 +12,12 @@ import pytest
 
 from typeagent.aitools.model_adapters import create_test_embedding_model
 from typeagent.aitools.vectorbase import TextEmbeddingIndexSettings
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.convsettings import (
     MessageTextIndexSettings,
     RelatedTermIndexSettings,
 )
 from typeagent.knowpro.interfaces import SemanticRef, TextLocation, TextRange
+from typeagent.knowpro.knowledge_schema import ConcreteEntity
 from typeagent.podcasts.podcast import PodcastMessage, PodcastMessageMeta
 from typeagent.storage import SqliteStorageProvider
 
@@ -73,23 +73,21 @@ async def test_related_terms_index_population_from_database(really_needs_auth):
             SemanticRef(
                 semantic_ref_ordinal=0,
                 range=TextRange(start=TextLocation(message_ordinal=0, chunk_ordinal=0)),
-                knowledge=kplib.ConcreteEntity(
+                knowledge=ConcreteEntity(
                     name="artificial intelligence", type=["technology", "concept"]
                 ),
             ),
             SemanticRef(
                 semantic_ref_ordinal=1,
                 range=TextRange(start=TextLocation(message_ordinal=1, chunk_ordinal=0)),
-                knowledge=kplib.ConcreteEntity(
+                knowledge=ConcreteEntity(
                     name="machine learning", type=["technology", "subset of AI"]
                 ),
             ),
             SemanticRef(
                 semantic_ref_ordinal=2,
                 range=TextRange(start=TextLocation(message_ordinal=2, chunk_ordinal=0)),
-                knowledge=kplib.ConcreteEntity(
-                    name="Python", type=["programming language"]
-                ),
+                knowledge=ConcreteEntity(name="Python", type=["programming language"]),
             ),
         ]
 
@@ -103,7 +101,7 @@ async def test_related_terms_index_population_from_database(really_needs_auth):
             knowledge = sem_ref.knowledge
             ref_ordinal = sem_ref.semantic_ref_ordinal
 
-            if isinstance(knowledge, kplib.ConcreteEntity):
+            if isinstance(knowledge, ConcreteEntity):
                 await semantic_ref_index.add_term(knowledge.name, ref_ordinal)
                 for type_name in knowledge.type:
                     await semantic_ref_index.add_term(type_name, ref_ordinal)

--- a/tests/test_storage_providers_unified.py
+++ b/tests/test_storage_providers_unified.py
@@ -20,7 +20,6 @@ from pydantic.dataclasses import dataclass
 
 from typeagent.aitools.embeddings import IEmbeddingModel
 from typeagent.aitools.vectorbase import TextEmbeddingIndexSettings
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.convsettings import (
     MessageTextIndexSettings,
     RelatedTermIndexSettings,
@@ -36,7 +35,12 @@ from typeagent.knowpro.interfaces import (
     TextRange,
     Topic,
 )
-from typeagent.knowpro.knowledge_schema import KnowledgeResponse
+from typeagent.knowpro.knowledge_schema import (
+    Action,
+    ConcreteEntity,
+    Facet,
+    KnowledgeResponse,
+)
 from typeagent.storage import SqliteStorageProvider
 from typeagent.storage.memory import MemoryStorageProvider
 
@@ -412,10 +416,10 @@ async def test_property_index_population_from_semantic_refs(
     entity_ref = SemanticRef(
         semantic_ref_ordinal=initial_sem_ref_count,
         range=text_range,
-        knowledge=kplib.ConcreteEntity(
+        knowledge=ConcreteEntity(
             name="Test Entity",
             type=["person", "speaker"],
-            facets=[kplib.Facet(name="role", value="host")],
+            facets=[Facet(name="role", value="host")],
         ),
     )
 
@@ -423,7 +427,7 @@ async def test_property_index_population_from_semantic_refs(
     action_ref = SemanticRef(
         semantic_ref_ordinal=initial_sem_ref_count + 1,
         range=text_range,
-        knowledge=kplib.Action(
+        knowledge=Action(
             verbs=["discuss", "explain"],
             verb_tense="present",
             subject_entity_name="Test Entity",

--- a/tools/benchmark_semref_writes.py
+++ b/tools/benchmark_semref_writes.py
@@ -27,9 +27,14 @@ import tempfile
 import time
 
 from typeagent.aitools.model_adapters import create_test_embedding_model
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.convsettings import ConversationSettings
 from typeagent.knowpro.interfaces_core import SemanticRef, Topic
+from typeagent.knowpro.knowledge_schema import (
+    Action,
+    ConcreteEntity,
+    Facet,
+    KnowledgeResponse,
+)
 from typeagent.storage.memory.semrefindex import (
     add_knowledge_batch_to_semantic_ref_index,
     text_range_from_message_chunk,
@@ -132,20 +137,18 @@ async def _individual_add_knowledge(
 # ---------------------------------------------------------------------------
 
 
-def synthetic_knowledge(chunk_index: int) -> kplib.KnowledgeResponse:
-    return kplib.KnowledgeResponse(
+def synthetic_knowledge(chunk_index: int) -> KnowledgeResponse:
+    return KnowledgeResponse(
         entities=[
-            kplib.ConcreteEntity(
+            ConcreteEntity(
                 name=f"entity_{chunk_index}_{j}",
                 type=[f"type_{j}", f"category_{chunk_index % 5}"],
-                facets=[
-                    kplib.Facet(name=f"facet_{j}", value=f"value_{j}") for j in range(2)
-                ],
+                facets=[Facet(name=f"facet_{j}", value=f"value_{j}") for j in range(2)],
             )
             for j in range(3)
         ],
         actions=[
-            kplib.Action(
+            Action(
                 verbs=[f"verb_{chunk_index}"],
                 verb_tense="past",
                 subject_entity_name=f"entity_{chunk_index}_0",

--- a/tools/query.py
+++ b/tools/query.py
@@ -38,15 +38,12 @@ from typeagent.aitools import embeddings, model_adapters, utils
 from typeagent.knowpro import (
     answer_response_schema,
     answers,
-)
-from typeagent.knowpro import (
     query,
     search,
     search_query_schema,
     searchlang,
     serialization,
 )
-from typeagent.knowpro import knowledge_schema as kplib
 from typeagent.knowpro.convsettings import ConversationSettings
 from typeagent.knowpro.interfaces import (
     IConversation,
@@ -57,6 +54,12 @@ from typeagent.knowpro.interfaces import (
     SemanticRef,
     Tag,
     Topic,
+)
+from typeagent.knowpro.knowledge_schema import (
+    Action,
+    ActionParam,
+    ConcreteEntity,
+    Quantity,
 )
 from typeagent.podcasts import podcast
 from typeagent.storage.utils import create_storage_provider
@@ -1229,19 +1232,19 @@ def summarize_knowledge(sem_ref: SemanticRef) -> str:
     if knowledge is None:
         return f"{sem_ref.semantic_ref_ordinal}: <No knowledge>"
 
-    if isinstance(knowledge, kplib.ConcreteEntity):
+    if isinstance(knowledge, ConcreteEntity):
         entity = knowledge
         res = [f"{entity.name} [{', '.join(entity.type)}]"]
         if entity.facets:
             for facet in entity.facets:
                 value = facet.value
-                if isinstance(value, kplib.Quantity):
+                if isinstance(value, Quantity):
                     value = f"{value.amount} {value.units}"
                 elif isinstance(value, float) and value.is_integer():
                     value = int(value)
                 res.append(f"<{facet.name}:{value}>")
         return f"{sem_ref.semantic_ref_ordinal}: {' '.join(res)}"
-    elif isinstance(knowledge, kplib.Action):
+    elif isinstance(knowledge, Action):
         action = knowledge
         res = []
         res.append("/".join(repr(verb) for verb in action.verbs))
@@ -1255,7 +1258,7 @@ def summarize_knowledge(sem_ref: SemanticRef) -> str:
             res.append(f"ind_obj={action.indirect_object_entity_name}")
         if action.params:
             for param in action.params:
-                if isinstance(param, kplib.ActionParam):
+                if isinstance(param, ActionParam):
                     res.append(f"<{param.name}:{param.value}>")
                 else:
                     res.append(f"<{param}>")


### PR DESCRIPTION
## Summary
- `knowledge_schema` exports classes only (`Quantity`, `Quantifier`, `Facet`, `ConcreteEntity`, `ActionParam`, `Action`, `KnowledgeResponse`), so per the import style guidelines in #299/AGENTS.md this is a direct-symbol-import case.
- Removes the `from . import knowledge_schema as kplib` alias (flagged as a smell in [#112](https://github.com/microsoft/typeagent-py/issues/112#issuecomment-4270060508)) everywhere it appears — 10 files in `src/typeagent`, 8 test files, 2 tool scripts — replacing `kplib.X` with a direct `from .knowledge_schema import X, Y, Z` import of the symbols actually used at each call site.
- Mechanical change only; no behavior change.
- Phase 1 of the import-consistency cleanup tracked in #298.

## Test plan
- [x] `make format check test` — 0 pyright errors (Python 3.12 and 3.14), 737 passed / 12 skipped