### PR TITLE
Use module-qualified imports for storage.memory.reltermsindex

### DIFF
--- a/src/typeagent/knowpro/search.py
+++ b/src/typeagent/knowpro/search.py
@@ -4,8 +4,8 @@
 from collections.abc import Callable
 from typing import cast, TypeGuard
 
+from ..storage.memory import reltermsindex
 from ..storage.memory.messageindex import IMessageTextEmbeddingIndex
-from ..storage.memory.reltermsindex import resolve_related_terms
 from .collections import MessageAccumulator, SemanticRefAccumulator
 from .dataclasses import dataclass
 from .field_helpers import CamelCaseField
@@ -507,7 +507,7 @@ class QueryCompiler:
             self.secondary_indexes is not None
             and self.secondary_indexes.term_to_related_terms_index is not None
         ):
-            await resolve_related_terms(
+            await reltermsindex.resolve_related_terms(
                 self.secondary_indexes.term_to_related_terms_index,
                 compiled_terms,
                 dedupe,

--- a/src/typeagent/knowpro/secindex.py
+++ b/src/typeagent/knowpro/secindex.py
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from ..storage.memory import reltermsindex
 from ..storage.memory.messageindex import build_message_index
 from ..storage.memory.propindex import build_property_index
-from ..storage.memory.reltermsindex import build_related_terms_index
 from ..storage.memory.timestampindex import build_timestamp_index
 from .convsettings import ConversationSettings, RelatedTermIndexSettings
 from .interfaces import (
@@ -45,7 +45,7 @@ async def build_secondary_indexes[
     else:
         storage_provider = await conversation_settings.get_storage_provider()
     await build_transient_secondary_indexes(conversation, conversation_settings)
-    await build_related_terms_index(
+    await reltermsindex.build_related_terms_index(
         conversation, conversation_settings.related_term_index_settings
     )
     if conversation.secondary_indexes is not None:

--- a/src/typeagent/storage/memory/provider.py
+++ b/src/typeagent/storage/memory/provider.py
@@ -5,6 +5,7 @@
 
 from datetime import datetime, timezone
 
+from . import reltermsindex
 from ...knowpro.convsettings import MessageTextIndexSettings, RelatedTermIndexSettings
 from ...knowpro.interfaces import (
     ChunkFailure,
@@ -23,7 +24,6 @@ from .collections import MemoryMessageCollection, MemorySemanticRefCollection
 from .convthreads import ConversationThreads
 from .messageindex import MessageTextIndex
 from .propindex import PropertyIndex
-from .reltermsindex import RelatedTermsIndex
 from .semrefindex import TermToSemanticRefIndex
 from .timestampindex import TimestampToTextRangeIndex
 
@@ -38,7 +38,7 @@ class MemoryStorageProvider[TMessage: IMessage](IStorageProvider[TMessage]):
     _property_index: PropertyIndex
     _timestamp_index: TimestampToTextRangeIndex
     _message_text_index: MessageTextIndex
-    _related_terms_index: RelatedTermsIndex
+    _related_terms_index: reltermsindex.RelatedTermsIndex
     _conversation_threads: ConversationThreads
     _ingested_sources: set[str]
     _chunk_failures: dict[tuple[int, int], ChunkFailure]
@@ -60,7 +60,9 @@ class MemoryStorageProvider[TMessage: IMessage](IStorageProvider[TMessage]):
         self._conversation_index = TermToSemanticRefIndex()
         self._property_index = PropertyIndex()
         self._timestamp_index = TimestampToTextRangeIndex()
-        self._related_terms_index = RelatedTermsIndex(related_terms_settings)
+        self._related_terms_index = reltermsindex.RelatedTermsIndex(
+            related_terms_settings
+        )
         thread_settings = message_text_settings.embedding_index_settings
         self._conversation_threads = ConversationThreads(thread_settings)
         self._ingested_sources = set()


### PR DESCRIPTION
## Summary
- `reltermsindex` (memory variant) exports a mix of classes (`TermToRelatedTermsMap`, `RelatedTermsIndex`, `TermEmbeddingIndex`) and functions (`build_related_terms_index`, `resolve_related_terms`, `dedupe_related_terms`), so per the import style guidelines in #299/AGENTS.md it defaults to module-qualified.
- Converts the 3 `src/typeagent` call sites (`knowpro/secindex.py`, `knowpro/search.py`, `storage/memory/provider.py`) from direct-symbol imports to `from ..storage.memory import reltermsindex` + qualified calls.
- Bonus: in `search.py`, `resolve_related_terms` was both a free function (imported) and a method on `QueryCompiler` — qualifying the import removes that latent name shadowing.
- The sqlite variant (`storage/sqlite/reltermsindex.py`) exports single classes each and is left as direct-symbol import — already compliant, no change.
- Scope: `src/typeagent` only, per #298 — test files keep direct-symbol imports, which is idiomatic pytest style.
- Phase 2 (1/3) of the import-consistency cleanup tracked in #298.

## Test plan
- [x] `make` (format, check on 3.12/3.14, test, build) — 0 pyright errors, 737 passed / 12 skipped, wheel builds