### PR TITLE
Use module-qualified imports for storage.memory.propindex

### DIFF
--- a/src/typeagent/knowpro/query.py
+++ b/src/typeagent/knowpro/query.py
@@ -7,8 +7,9 @@ from dataclasses import dataclass, field
 from typing import cast, Literal, Protocol
 
 from ..aitools.embeddings import NormalizedEmbedding
+from ..storage.memory import propindex
 from ..storage.memory.messageindex import IMessageTextEmbeddingIndex
-from ..storage.memory.propindex import lookup_property_in_property_index, PropertyNames
+from ..storage.memory.propindex import PropertyNames
 from .collections import (
     Match,
     MatchAccumulator,
@@ -600,7 +601,7 @@ class MatchPropertySearchTermExpr(MatchTermExpr):
         property_value: str,
     ) -> list[ScoredSemanticRefOrdinal] | None:
         if context.property_index is not None:
-            return await lookup_property_in_property_index(
+            return await propindex.lookup_property_in_property_index(
                 context.property_index,
                 property_name,
                 property_value,

--- a/src/typeagent/knowpro/secindex.py
+++ b/src/typeagent/knowpro/secindex.py
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+from ..storage.memory import propindex
 from ..storage.memory.messageindex import build_message_index
-from ..storage.memory.propindex import build_property_index
 from ..storage.memory.reltermsindex import build_related_terms_index
 from ..storage.memory.timestampindex import build_timestamp_index
 from .convsettings import ConversationSettings, RelatedTermIndexSettings
@@ -66,5 +66,5 @@ async def build_transient_secondary_indexes[
             await settings.get_storage_provider(),
             settings.related_term_index_settings,
         )
-    await build_property_index(conversation)
+    await propindex.build_property_index(conversation)
     await build_timestamp_index(conversation)

--- a/src/typeagent/storage/memory/provider.py
+++ b/src/typeagent/storage/memory/provider.py
@@ -5,6 +5,7 @@
 
 from datetime import datetime, timezone
 
+from . import propindex
 from ...knowpro.convsettings import MessageTextIndexSettings, RelatedTermIndexSettings
 from ...knowpro.interfaces import (
     ChunkFailure,
@@ -22,7 +23,6 @@ from ...knowpro.interfaces import (
 from .collections import MemoryMessageCollection, MemorySemanticRefCollection
 from .convthreads import ConversationThreads
 from .messageindex import MessageTextIndex
-from .propindex import PropertyIndex
 from .reltermsindex import RelatedTermsIndex
 from .semrefindex import TermToSemanticRefIndex
 from .timestampindex import TimestampToTextRangeIndex
@@ -35,7 +35,7 @@ class MemoryStorageProvider[TMessage: IMessage](IStorageProvider[TMessage]):
     _semantic_ref_collection: MemorySemanticRefCollection
 
     _conversation_index: TermToSemanticRefIndex
-    _property_index: PropertyIndex
+    _property_index: propindex.PropertyIndex
     _timestamp_index: TimestampToTextRangeIndex
     _message_text_index: MessageTextIndex
     _related_terms_index: RelatedTermsIndex
@@ -58,7 +58,7 @@ class MemoryStorageProvider[TMessage: IMessage](IStorageProvider[TMessage]):
         self._semantic_ref_collection = MemorySemanticRefCollection()
 
         self._conversation_index = TermToSemanticRefIndex()
-        self._property_index = PropertyIndex()
+        self._property_index = propindex.PropertyIndex()
         self._timestamp_index = TimestampToTextRangeIndex()
         self._related_terms_index = RelatedTermsIndex(related_terms_settings)
         thread_settings = message_text_settings.embedding_index_settings

--- a/src/typeagent/storage/sqlite/propindex.py
+++ b/src/typeagent/storage/sqlite/propindex.py
@@ -8,10 +8,7 @@ import sqlite3
 
 from ...knowpro import interfaces
 from ...knowpro.interfaces import ScoredSemanticRefOrdinal
-from ...storage.memory.propindex import (
-    make_property_term_text,
-    split_property_term_text,
-)
+from ...storage.memory import propindex
 
 
 class SqlitePropertyIndex(interfaces.IPropertyToSemanticRefIndex):
@@ -51,9 +48,9 @@ class SqlitePropertyIndex(interfaces.IPropertyToSemanticRefIndex):
             score = 1.0
 
         # Normalize property name and value (to match in-memory implementation)
-        term_text = make_property_term_text(property_name, value)
+        term_text = propindex.make_property_term_text(property_name, value)
         term_text = term_text.lower()  # Matches PropertyIndex._prepare_term_text
-        property_name, value = split_property_term_text(term_text)
+        property_name, value = propindex.split_property_term_text(term_text)
         # Remove "prop." prefix that was added by make_property_term_text
         if property_name.startswith("prop."):
             property_name = property_name[5:]
@@ -87,9 +84,9 @@ class SqlitePropertyIndex(interfaces.IPropertyToSemanticRefIndex):
             else:
                 semref_id = ordinal
                 score = 1.0
-            term_text = make_property_term_text(property_name, value)
+            term_text = propindex.make_property_term_text(property_name, value)
             term_text = term_text.lower()
-            property_name, value = split_property_term_text(term_text)
+            property_name, value = propindex.split_property_term_text(term_text)
             if property_name.startswith("prop."):
                 property_name = property_name[5:]
             rows.append((property_name, value, score, semref_id))
@@ -109,9 +106,9 @@ class SqlitePropertyIndex(interfaces.IPropertyToSemanticRefIndex):
         value: str,
     ) -> list[interfaces.ScoredSemanticRefOrdinal] | None:
         # Normalize property name and value (to match in-memory implementation)
-        term_text = make_property_term_text(property_name, value)
+        term_text = propindex.make_property_term_text(property_name, value)
         term_text = term_text.lower()  # Matches PropertyIndex._prepare_term_text
-        property_name, value = split_property_term_text(term_text)
+        property_name, value = propindex.split_property_term_text(term_text)
         # Remove "prop." prefix that was added by make_property_term_text
         if property_name.startswith("prop."):
             property_name = property_name[5:]


### PR DESCRIPTION
## Summary
- `propindex` (memory variant) exports an enum (`PropertyNames`), ~10 functions, and a class (`PropertyIndex`). Per the import style guidelines in #299/AGENTS.md, low-frequency symbols default to module-qualified:
  - `knowpro/query.py`: `lookup_property_in_property_index`
  - `knowpro/secindex.py`: `build_property_index`
  - `storage/memory/provider.py`: `PropertyIndex`
  - `storage/sqlite/propindex.py`: `make_property_term_text`, `split_property_term_text` (cross-imported from the memory variant)
- `PropertyNames` is deliberately left as a direct-symbol import everywhere it's used (`query.py`, `searchlang.py`, `searchlib.py`) — it's referenced 20+ times across those files, which squarely matches AGENTS.md's "avoiding severe repetitive visual clutter" exception. Qualifying every `PropertyNames.X` reference would add clutter with no disambiguation benefit.
- The sqlite variant's own class (`SqlitePropertyIndex`) exports a single class and is left as direct-symbol import — already compliant, no change.
- Scope: `src/typeagent` only, per #298.
- Phase 2 (2/3) of the import-consistency cleanup tracked in #298. Builds on the same approach as #301 (reltermsindex).

## Test plan
- [x] `make` (format, check on 3.12/3.14, test, build) — 0 pyright errors, 737 passed / 12 skipped, wheel builds