### PR TITLE
Use module-qualified imports for storage.memory.semrefindex

### DIFF
--- a/src/typeagent/knowpro/add_messages.py
+++ b/src/typeagent/knowpro/add_messages.py
@@ -13,7 +13,7 @@ import typechat
 
 from . import knowledge_schema as kplib
 from ..aitools.embeddings import IEmbeddingModel, NormalizedEmbedding
-from ..storage.memory.semrefindex import collect_action_terms, collect_entity_terms
+from ..storage.memory import semrefindex
 from .interfaces import AddMessagesResult
 from .interfaces_core import IKnowledgeExtractor, IMessage, MessageOrdinal, TextLocation
 
@@ -251,11 +251,11 @@ def _collect_related_terms_for_fuzzy_index(
             related_terms.append(canonical)
 
     for entity in knowledge.entities:
-        for term in collect_entity_terms(entity):
+        for term in semrefindex.collect_entity_terms(entity):
             _add_term(term)
 
     for action in chain(knowledge.actions, knowledge.inverse_actions):
-        for term in collect_action_terms(action):
+        for term in semrefindex.collect_action_terms(action):
             _add_term(term)
 
     for topic in knowledge.topics:

--- a/src/typeagent/mcp/server.py
+++ b/src/typeagent/mcp/server.py
@@ -30,7 +30,7 @@ from typeagent.knowpro.answer_response_schema import AnswerResponse
 from typeagent.knowpro.convsettings import ConversationSettings
 from typeagent.knowpro.search_query_schema import SearchQuery
 from typeagent.podcasts import podcast
-from typeagent.storage.memory.semrefindex import TermToSemanticRefIndex
+from typeagent.storage.memory import semrefindex
 from typeagent.storage.utils import create_storage_provider
 
 # Example podcast index path for documentation and error messages
@@ -104,7 +104,7 @@ class ProcessingContext:
     lang_search_options: searchlang.LanguageSearchOptions
     answer_context_options: answers.AnswerContextOptions
     query_context: query.QueryEvalContext[
-        podcast.PodcastMessage, TermToSemanticRefIndex
+        podcast.PodcastMessage, semrefindex.TermToSemanticRefIndex
     ]
     embedding_model: embeddings.IEmbeddingModel
     query_translator: typechat.TypeChatJsonTranslator[SearchQuery]

--- a/src/typeagent/storage/memory/provider.py
+++ b/src/typeagent/storage/memory/provider.py
@@ -5,6 +5,7 @@
 
 from datetime import datetime, timezone
 
+from . import semrefindex
 from ...knowpro.convsettings import MessageTextIndexSettings, RelatedTermIndexSettings
 from ...knowpro.interfaces import (
     ChunkFailure,
@@ -24,7 +25,6 @@ from .convthreads import ConversationThreads
 from .messageindex import MessageTextIndex
 from .propindex import PropertyIndex
 from .reltermsindex import RelatedTermsIndex
-from .semrefindex import TermToSemanticRefIndex
 from .timestampindex import TimestampToTextRangeIndex
 
 
@@ -34,7 +34,7 @@ class MemoryStorageProvider[TMessage: IMessage](IStorageProvider[TMessage]):
     _message_collection: MemoryMessageCollection[TMessage]
     _semantic_ref_collection: MemorySemanticRefCollection
 
-    _conversation_index: TermToSemanticRefIndex
+    _conversation_index: semrefindex.TermToSemanticRefIndex
     _property_index: PropertyIndex
     _timestamp_index: TimestampToTextRangeIndex
     _message_text_index: MessageTextIndex
@@ -57,7 +57,7 @@ class MemoryStorageProvider[TMessage: IMessage](IStorageProvider[TMessage]):
         )
         self._semantic_ref_collection = MemorySemanticRefCollection()
 
-        self._conversation_index = TermToSemanticRefIndex()
+        self._conversation_index = semrefindex.TermToSemanticRefIndex()
         self._property_index = PropertyIndex()
         self._timestamp_index = TimestampToTextRangeIndex()
         self._related_terms_index = RelatedTermsIndex(related_terms_settings)


### PR DESCRIPTION
## Summary
- `semrefindex` (memory variant) is overwhelmingly function-oriented (18 functions + 1 class), so per the import style guidelines in #299/AGENTS.md it defaults to module-qualified.
- Converts the remaining low-frequency direct-symbol call sites:
  - `knowpro/add_messages.py`: `collect_action_terms`, `collect_entity_terms`
  - `mcp/server.py`: `TermToSemanticRefIndex`
  - `storage/memory/provider.py`: `TermToSemanticRefIndex`
- `conversation_base.py` already used `from ..storage.memory import semrefindex` + qualified calls for its 4 function usages, so no change was needed there — this PR brings the rest of `src/typeagent` in line with that existing convention.
- The sqlite variant's own class (`SqliteTermToSemanticRefIndex`) exports a single class and is left as direct-symbol import — already compliant, no change.
- Scope: `src/typeagent` only, per #298.
- Phase 2 (3/3, final) of the import-consistency cleanup tracked in #298. Companion PRs: #301 (reltermsindex), #302 (propindex).

## Test plan
- [x] `make` (format, check on 3.12/3.14, test, build) — 0 pyright errors, 737 passed / 12 skipped, wheel builds