### PR TITLE
Stop bypassing the knowpro.interfaces aggregator

### DIFF
--- a/src/typeagent/knowpro/add_messages.py
+++ b/src/typeagent/knowpro/add_messages.py
@@ -14,8 +14,13 @@ import typechat
 from . import knowledge_schema as kplib
 from ..aitools.embeddings import IEmbeddingModel, NormalizedEmbedding
 from ..storage.memory.semrefindex import collect_action_terms, collect_entity_terms
-from .interfaces import AddMessagesResult
-from .interfaces_core import IKnowledgeExtractor, IMessage, MessageOrdinal, TextLocation
+from .interfaces import (
+    AddMessagesResult,
+    IKnowledgeExtractor,
+    IMessage,
+    MessageOrdinal,
+    TextLocation,
+)
 
 __all__ = ["add_messages_streaming"]
 

--- a/src/typeagent/knowpro/conversation_base.py
+++ b/src/typeagent/knowpro/conversation_base.py
@@ -37,9 +37,9 @@ from .interfaces import (
     IStorageProvider,
     ITermToSemanticRefIndex,
     MessageOrdinal,
+    TextLocation,
     Topic,
 )
-from .interfaces_core import TextLocation
 from .messageutils import get_all_message_chunk_locations
 
 TMessage = TypeVar("TMessage", bound=IMessage)

--- a/src/typeagent/podcasts/podcast_ingest.py
+++ b/src/typeagent/podcasts/podcast_ingest.py
@@ -8,8 +8,7 @@ import re
 import time
 
 from ..knowpro.convsettings import ConversationSettings
-from ..knowpro.interfaces import Datetime
-from ..knowpro.interfaces_core import AddMessagesResult
+from ..knowpro.interfaces import AddMessagesResult, Datetime
 from ..knowpro.universal_message import format_timestamp_utc, UNIX_EPOCH
 from ..storage.utils import create_storage_provider
 from .podcast import Podcast, PodcastMessage, PodcastMessageMeta

--- a/src/typeagent/storage/sqlite/provider.py
+++ b/src/typeagent/storage/sqlite/provider.py
@@ -10,8 +10,7 @@ from ...aitools.model_adapters import create_embedding_model
 from ...aitools.vectorbase import TextEmbeddingIndexSettings
 from ...knowpro import interfaces
 from ...knowpro.convsettings import MessageTextIndexSettings, RelatedTermIndexSettings
-from ...knowpro.interfaces import ConversationMetadata, STATUS_INGESTED
-from ...knowpro.interfaces_storage import ChunkFailure
+from ...knowpro.interfaces import ChunkFailure, ConversationMetadata, STATUS_INGESTED
 from ..memory.convthreads import ConversationThreads
 from .collections import SqliteMessageCollection, SqliteSemanticRefCollection
 from .messageindex import SqliteMessageTextIndex


### PR DESCRIPTION
## Summary
`interfaces.py` explicitly re-exports `interfaces_core`/`interfaces_indexes`/`interfaces_search`/`interfaces_serialization`/`interfaces_storage` via `__all__` (exempted from AGENTS.md's "no re-export" rule by its own exception clause), but 4 files partially imported some symbols through it and others directly from the defining submodule:

- `conversation_base.py`: `TextLocation` (from `interfaces_core`)
- `add_messages.py`: `IKnowledgeExtractor`, `IMessage`, `MessageOrdinal`, `TextLocation` (from `interfaces_core`)
- `storage/sqlite/provider.py`: `ChunkFailure` (from `interfaces_storage`)
- `podcast_ingest.py`: `AddMessagesResult` (from `interfaces_core`)

Investigated and ruled out both plausible justifications (details in #298):
- **Not a circular-import workaround** — none of the `interfaces_*.py` submodules import anything from these 4 files.
- **Not a missing-export issue** — every bypassed symbol is confirmed present in the relevant submodule's `__all__`.

Git history shows the bypass lines were added months after the aggregator existed (2025-12-31), across unrelated feature commits (streaming API, batching/pipeline overlap) with no import-style rationale — incidental, not deliberate.

Merges each bypassed import into the existing (or a new) `from .interfaces import (...)` block.

Found via a whole-project import-style scan, tracked in #298.

## Test plan
- [x] `make` (format, check on 3.12/3.14, test, build) — 0 pyright errors, 737 passed / 12 skipped, wheel builds