### PR TITLE
Fix date-only range stop dropping the final day (half-open [start, stop))

### DIFF
--- a/src/typeagent/knowpro/convutils.py
+++ b/src/typeagent/knowpro/convutils.py
@@ -35,6 +35,13 @@ async def get_time_range_for_conversation[
 ](
     conversation: IConversation[TMessage, TIndex],
 ) -> DateRange | None:
+    """The conversation's span, for display in a prompt.
+
+    The end is the last message's own timestamp, or None if it has none (the
+    prompt renders that as "now"). It is an inclusive-looking bound, so do NOT
+    pass this range to a timestamp index lookup: `DateRange` is half-open and
+    the last message would fall outside it.
+    """
     messages = conversation.messages
     size = await messages.size()
     if size > 0:

--- a/src/typeagent/knowpro/interfaces_core.py
+++ b/src/typeagent/knowpro/interfaces_core.py
@@ -360,8 +360,16 @@ class SemanticRef:
 
 @dataclass
 class DateRange:
+    """A half-open interval `[start, end)`: the end is EXCLUSIVE.
+
+    So "the whole of Jan 5" is `[Jan 5 00:00, Jan 6 00:00)`, and a caller
+    holding an inclusive bound must pass something strictly greater as `end`.
+    NOTE: `end is None` means "unbounded" here, but the timestamp indexes treat
+    a missing end as a point query.
+    """
+
     start: Datetime
-    end: Datetime | None = None  # inclusive; None means unbounded
+    end: Datetime | None = None  # exclusive; None means unbounded
 
     def __repr__(self) -> str:
         if self.end is None:
@@ -372,7 +380,7 @@ class DateRange:
     def __contains__(self, datetime: Datetime) -> bool:
         if self.end is None:
             return self.start <= datetime
-        return self.start <= datetime <= self.end
+        return self.start <= datetime < self.end
 
 
 @dataclass(unsafe_hash=True)

--- a/src/typeagent/knowpro/searchlang.py
+++ b/src/typeagent/knowpro/searchlang.py
@@ -670,7 +670,7 @@ def date_range_from_datetime_range(date_time_range: DateTimeRange) -> DateRange:
     return DateRange(
         start=datetime_from_date_time(date_time_range.start_date),
         end=(
-            datetime_from_date_time(date_time_range.stop_date)
+            exclusive_stop_from_date_time(date_time_range.stop_date)
             if date_time_range.stop_date
             else None
         ),
@@ -678,6 +678,8 @@ def date_range_from_datetime_range(date_time_range: DateTimeRange) -> DateRange:
 
 
 def datetime_from_date_time(date_time: DateTime) -> Datetime:
+    # A missing time means midnight, i.e. the START of a range;
+    # for the stop use exclusive_stop_from_date_time().
     # We ASSUME that the LLM gave the DateTime in UTC.
     # If it didn't, well, how would we know???
     dt = Datetime(
@@ -690,6 +692,18 @@ def datetime_from_date_time(date_time: DateTime) -> Datetime:
         tzinfo=datetime.timezone.utc,
     )
     return dt
+
+
+def exclusive_stop_from_date_time(date_time: DateTime) -> Datetime:
+    """The exclusive end of a half-open DateRange.
+
+    A bare date names a whole day, so roll to the next midnight -- otherwise
+    "Jan 1 to Jan 5" drops all of Jan 5. An explicit time is already exclusive.
+    """
+    stop = datetime_from_date_time(date_time)
+    if date_time.time is None:
+        stop += datetime.timedelta(days=1)
+    return stop
 
 
 # TODO: Move to searchquerytranslator.py?

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -152,6 +152,26 @@ def test_text_range_contains_with_none_end():
     assert same_point in point_range
 
 
+def test_date_range_contains_is_half_open():
+    """DateRange is [start, end): start is in, end is out."""
+    date_range = DateRange(start=Datetime(2025, 1, 1), end=Datetime(2025, 1, 10))
+
+    assert Datetime(2025, 1, 1) in date_range
+    assert Datetime(2025, 1, 5, 12, 30) in date_range
+    assert Datetime(2025, 1, 9, 23, 59, 59, 999999) in date_range
+    assert Datetime(2025, 1, 10) not in date_range  # exclusive end
+    assert Datetime(2024, 12, 31, 23, 59, 59) not in date_range
+
+
+def test_date_range_contains_with_none_end():
+    """A DateRange with no end is unbounded above."""
+    date_range = DateRange(start=Datetime(2025, 1, 1))
+
+    assert Datetime(2025, 1, 1) in date_range
+    assert Datetime(2099, 12, 31) in date_range
+    assert Datetime(2024, 12, 31) not in date_range
+
+
 def test_text_range_contains_both_none_end():
     """Test __contains__ when both ranges have None end."""
     # Both ranges are point ranges

--- a/tests/test_searchlang_compile.py
+++ b/tests/test_searchlang_compile.py
@@ -24,6 +24,7 @@ from typeagent.knowpro.searchlang import (
     compile_search_query,
     date_range_from_datetime_range,
     datetime_from_date_time,
+    exclusive_stop_from_date_time,
     is_entity_term_list,
     LanguageQueryCompileOptions,
     LanguageSearchFilter,
@@ -134,7 +135,8 @@ class TestOptimizeOrMax:
 
 
 # ---------------------------------------------------------------------------
-# date_range_from_datetime_range / datetime_from_date_time
+# date_range_from_datetime_range / datetime_from_date_time /
+# exclusive_stop_from_date_time
 # ---------------------------------------------------------------------------
 
 
@@ -161,6 +163,31 @@ class TestDatetimeFromDateTime:
         assert dt.second == 45
 
 
+class TestExclusiveStopFromDateTime:
+    def test_date_only_rolls_to_next_midnight(self) -> None:
+        stop = exclusive_stop_from_date_time(
+            DateTime(date=DateVal(day=15, month=6, year=2024))
+        )
+        assert stop == datetime.datetime(2024, 6, 16, tzinfo=datetime.timezone.utc)
+
+    def test_month_end_rolls_over(self) -> None:
+        stop = exclusive_stop_from_date_time(
+            DateTime(date=DateVal(day=29, month=2, year=2024))  # leap day
+        )
+        assert stop == datetime.datetime(2024, 3, 1, tzinfo=datetime.timezone.utc)
+
+    def test_explicit_time_is_kept(self) -> None:
+        stop = exclusive_stop_from_date_time(
+            DateTime(
+                date=DateVal(day=15, month=6, year=2024),
+                time=TimeVal(hour=14, minute=30, seconds=45),
+            )
+        )
+        assert stop == datetime.datetime(
+            2024, 6, 15, 14, 30, 45, tzinfo=datetime.timezone.utc
+        )
+
+
 class TestDateRangeFromDatetimeRange:
     def test_start_only(self) -> None:
         dtr = DateTimeRange(
@@ -178,9 +205,45 @@ class TestDateRangeFromDatetimeRange:
         dr = date_range_from_datetime_range(dtr)
         assert dr.start.year == 2023
         assert dr.end is not None
-        assert dr.end.year == 2023
-        assert dr.end.month == 12
-        assert dr.end.day == 31
+        # DateRange is half-open, so a date-only stop of Dec 31 becomes
+        # midnight of Jan 1 -- that is how Dec 31 itself gets included.
+        assert (dr.end.year, dr.end.month, dr.end.day) == (2024, 1, 1)
+
+    def test_date_only_stop_covers_whole_day(self) -> None:
+        # Regression test: a stop date with no time used to compile to that
+        # day's midnight, so the whole final day fell outside the range.
+        dtr = DateTimeRange(
+            start_date=DateTime(date=DateVal(day=1, month=1, year=2023)),
+            stop_date=DateTime(date=DateVal(day=5, month=1, year=2023)),
+        )
+        dr = date_range_from_datetime_range(dtr)
+        assert dr.end is not None
+        assert dr.end == datetime.datetime(2023, 1, 6, tzinfo=datetime.timezone.utc)
+        for hour, minute in ((0, 0), (9, 30), (23, 59)):
+            assert (
+                datetime.datetime(
+                    2023, 1, 5, hour, minute, tzinfo=datetime.timezone.utc
+                )
+                in dr
+            )
+        # ... and the exclusive bound itself is out.
+        assert dr.end not in dr
+
+    def test_stop_with_time_is_exclusive_bound(self) -> None:
+        # An explicit time is already the exclusive bound: keep it as-is.
+        dtr = DateTimeRange(
+            start_date=DateTime(date=DateVal(day=1, month=1, year=2023)),
+            stop_date=DateTime(
+                date=DateVal(day=5, month=1, year=2023),
+                time=TimeVal(hour=10, minute=0, seconds=0),
+            ),
+        )
+        dr = date_range_from_datetime_range(dtr)
+        assert dr.end is not None
+        assert dr.end == datetime.datetime(
+            2023, 1, 5, 10, 0, tzinfo=datetime.timezone.utc
+        )
+        assert dr.end not in dr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replaces #296 and #309. @bmerkle offered on #296 to hand this back to me to land, and I took him up on it; GitHub refused to reopen #296 after the force-push, hence a new PR. The design and the test shape are his — he is credited on the commit.

A `stop_date` with no time compiled to that day's midnight, so "Jan 1 to Jan 5" became `[Jan 1 00:00, Jan 5 00:00)` and everything on Jan 5 was dropped.

- `searchlang.py`: new `exclusive_stop_from_date_time()`; a date-only stop rolls to the next midnight.
- `interfaces_core.py`: `DateRange.end` is now documented and implemented as exclusive (`__contains__` uses `<`), matching both timestamp index backends, which already filtered exclusively.
- `convutils.py`: docstring only, warning that `get_time_range_for_conversation` returns an inclusive-looking bound.

`end is None` still means "unbounded" in `DateRange` but a point query in the indexes. Left alone — separate decision.

`make format check test`: pyright clean on 3.12 and 3.14, **744 passed, 12 skipped** (737 on `main`; the 7 new tests are the only difference). The regression test fails on `main` and passes here.
